### PR TITLE
Fix for MSVC Compile Warning

### DIFF
--- a/src/dl_txt_read.h
+++ b/src/dl_txt_read.h
@@ -7,10 +7,10 @@
 
 struct dl_txt_read_ctx
 {
+	jmp_buf jumpbuf;
 	const char* start;
 	const char* iter;
 	dl_error_t err;
-	jmp_buf jumpbuf;
 };
 
 struct dl_txt_read_substr


### PR DESCRIPTION
C4324 - structure was padded due to __declspec(align())

Bad structure alignment fix.