### PR TITLE
Moved shared functions to a shared file

### DIFF
--- a/src/dl_txt_unpack.cpp
+++ b/src/dl_txt_unpack.cpp
@@ -1,21 +1,9 @@
 /* copyright (c) 2010 Fredrik Kihlander, see LICENSE for more info */
 
+#include "dl_util.h"
 #include "dl_types.h"
 #include "dl_binary_writer.h"
 #include <dl/dl_txt.h>
-
-#if defined( __GNUC__ )
-static inline int dl_internal_str_format(char* DL_RESTRICT buf, size_t buf_size, const char* DL_RESTRICT fmt, ...) __attribute__((format( printf, 3, 4 )));
-#endif
-static inline int dl_internal_str_format(char* DL_RESTRICT buf, size_t buf_size, const char* DL_RESTRICT fmt, ...)
-{
-	va_list args;
-	va_start( args, fmt );
-	int res = vsnprintf( buf, buf_size, fmt, args );
-	buf[buf_size - 1] = '\0';
-	va_end( args );
-	return res;
-}
 
 struct dl_txt_unpack_ctx
 {

--- a/src/dl_typelib_read_bin.cpp
+++ b/src/dl_typelib_read_bin.cpp
@@ -1,4 +1,5 @@
 #include <dl/dl_typelib.h>
+#include "dl_util.h"
 #include "dl_types.h"
 
 static dl_error_t dl_internal_load_type_library_defaults( dl_ctx_t       dl_ctx,
@@ -68,16 +69,6 @@ static void dl_endian_swap_member_desc( dl_member_desc* desc )
 static void dl_endian_swap_enum_value_desc( dl_enum_value_desc* desc )
 {
 	desc->value = dl_swap_endian_uint32( desc->value );
-}
-
-template <typename T>
-static T* dl_grow_array( dl_allocator* alloc, T* ptr, size_t* cap, size_t need )
-{
-	size_t old_cap = *cap;
-	if( need < old_cap )
-		return ptr;
-	*cap = need;
-	return (T*)dl_realloc( alloc, ptr, need * sizeof( T ), old_cap * sizeof( T ) );
 }
 
 dl_error_t dl_context_load_type_library( dl_ctx_t dl_ctx, const unsigned char* lib_data, size_t lib_data_size )

--- a/src/dl_typelib_read_txt.cpp
+++ b/src/dl_typelib_read_txt.cpp
@@ -1,22 +1,12 @@
 #include <dl/dl_typelib.h>
 #include <dl/dl_txt.h>
+#include "dl_util.h"
 #include "dl_types.h"
 #include "dl_alloc.h"
 #include "dl_txt_read.h"
 
 #include <stdlib.h> // strtoul
 #include <ctype.h>
-
-template <typename T>
-static T* dl_grow_array( dl_allocator* alloc, T* ptr, size_t* cap, size_t min_inc )
-{
-	size_t old_cap = *cap;
-	size_t new_cap = ( ( old_cap < min_inc ) ? old_cap + min_inc : old_cap ) * 2;
-	if( new_cap == 0 )
-		new_cap = 8;
-	*cap = new_cap;
-	return (T*)dl_realloc( alloc, ptr, new_cap * sizeof( T ), old_cap * sizeof( T ) );
-}
 
 static uint32_t dl_alloc_string( dl_ctx_t ctx, dl_txt_read_substr* str )
 {
@@ -190,16 +180,6 @@ static const dl_builtin_type* dl_find_builtin_type( const char* name )
 static dl_type_t dl_make_type( dl_type_t atom, dl_type_t storage )
 {
 	return (dl_type_t)( (unsigned int)atom | (unsigned int)storage );
-}
-
-static inline int dl_internal_str_format(char* DL_RESTRICT buf, size_t buf_size, const char* DL_RESTRICT fmt, ...)
-{
-	va_list args;
-	va_start( args, fmt );
-	int res = vsnprintf( buf, buf_size, fmt, args );
-	buf[buf_size - 1] = '\0';
-	va_end( args );
-	return res;
 }
 
 static void dl_load_txt_build_default_data( dl_ctx_t ctx, dl_txt_read_ctx* read_state, unsigned int member_index )
@@ -650,7 +630,7 @@ static int dl_parse_type( dl_ctx_t ctx, dl_txt_read_substr* type, dl_member_desc
 	const char* iter = type->str;
 	const char* end  = type->str + type->len;
 
-	while( ( isalnum( *iter ) || *iter == '_' ) && ( iter != end ) )
+	while( ( iter != end ) && ( isalnum( *iter ) || *iter == '_' )  )
 	{
 		type_name[type_name_len++] = *iter;
 		++iter;

--- a/src/dl_util.h
+++ b/src/dl_util.h
@@ -4,6 +4,7 @@
 #define DL_DL_UTIL_H_INCLUDED
 
 #include "dl_alloc.h"
+#include <stdarg.h>
 
 template <typename T>
 static T* dl_grow_array( dl_allocator* alloc, T* ptr, size_t* cap, size_t min_inc )

--- a/src/dl_util.h
+++ b/src/dl_util.h
@@ -3,6 +3,8 @@
 #ifndef DL_DL_UTIL_H_INCLUDED
 #define DL_DL_UTIL_H_INCLUDED
 
+#include "dl_alloc.h"
+
 template <typename T>
 static T* dl_grow_array( dl_allocator* alloc, T* ptr, size_t* cap, size_t min_inc )
 {

--- a/src/dl_util.h
+++ b/src/dl_util.h
@@ -4,7 +4,8 @@
 #define DL_DL_UTIL_H_INCLUDED
 
 #include "dl_alloc.h"
-#include <stdarg.h>
+#include <stdio.h> // vsnprintf
+#include <stdarg.h> // va_start, va_end
 
 template <typename T>
 static T* dl_grow_array( dl_allocator* alloc, T* ptr, size_t* cap, size_t min_inc )

--- a/src/dl_util.h
+++ b/src/dl_util.h
@@ -1,0 +1,31 @@
+/* copyright (c) 2010 Fredrik Kihlander, see LICENSE for more info */
+
+#ifndef DL_DL_UTIL_H_INCLUDED
+#define DL_DL_UTIL_H_INCLUDED
+
+template <typename T>
+static T* dl_grow_array( dl_allocator* alloc, T* ptr, size_t* cap, size_t min_inc )
+{
+	size_t old_cap = *cap;
+	size_t new_cap = ( ( old_cap < min_inc ) ? old_cap + min_inc : old_cap ) * 2;
+	if( new_cap == 0 )
+		new_cap = 8;
+	*cap = new_cap;
+	return (T*)dl_realloc( alloc, ptr, new_cap * sizeof( T ), old_cap * sizeof( T ) );
+}
+
+#if defined( __GNUC__ )
+static inline int dl_internal_str_format(char* DL_RESTRICT buf, size_t buf_size, const char* DL_RESTRICT fmt, ...) __attribute__((format( printf, 3, 4 )));
+#endif
+static inline int dl_internal_str_format(char* DL_RESTRICT buf, size_t buf_size, const char* DL_RESTRICT fmt, ...)
+{
+	va_list args;
+	va_start( args, fmt );
+	int res = vsnprintf( buf, buf_size, fmt, args );
+	buf[buf_size - 1] = '\0';
+	va_end( args );
+	return res;
+}
+
+#endif // DL_DL_UTIL_H_INCLUDED
+


### PR DESCRIPTION
The functions dl_internal_str_format and dl_grow_array were duplicated in multiple source files. I moved them to a new shared header-file, dl_util.h in order to be able to just include all the source-files to one unity-build.