### PR TITLE
Fix for bitfield defaults

### DIFF
--- a/src/dl_txt_pack.cpp
+++ b/src/dl_txt_pack.cpp
@@ -882,7 +882,6 @@ static void dl_txt_pack_eat_and_write_struct( dl_ctx_t dl_ctx, dl_txt_pack_ctx* 
 			{
 				uint32_t bf_bits = member->BitFieldBits();
 				uint32_t bf_offset = member->BitFieldOffset();
-				uint64_t max_val = (uint64_t(1) << bf_bits) - uint64_t(1);
 
 				dl_binary_writer_seek_set( packctx->writer, member_pos );
 
@@ -911,9 +910,6 @@ static void dl_txt_pack_eat_and_write_struct( dl_ctx_t dl_ctx, dl_txt_pack_ctx* 
 						break;
 				}
 				uint64_t default_value_extracted = DL_EXTRACT_BITS(default_value, dl_bf_offset( DL_ENDIAN_HOST, sizeof(uint8_t), bf_offset, bf_bits ), bf_bits);
-				if(default_value_extracted > max_val)
-					dl_txt_read_failed( dl_ctx, &packctx->read_ctx, DL_ERROR_INVALID_DEFAULT_VALUE, "member %s.%s has a default value that is too big", dl_internal_type_name( dl_ctx, type ), dl_internal_member_name( dl_ctx, member ) );
-
 				uint64_t to_store = DL_INSERT_BITS( current_data, default_value_extracted, dl_bf_offset( DL_ENDIAN_HOST, sizeof(uint8_t), bf_offset, bf_bits ), bf_bits );
 				dl_binary_writer_seek_set( packctx->writer, member_pos );
 

--- a/tests/dl_tests_txt.cpp
+++ b/tests/dl_tests_txt.cpp
@@ -212,6 +212,24 @@ TEST_F(DLText, default_value_bitfield)
 	EXPECT_EQ(3, loaded.f6);
 }
 
+TEST_F(DLText, default_value_bitfield_bool)
+{
+	const char* text_data = STRINGIFY( { "BitfieldDefaultsMulti" : { "f1" : true, "f5" : true } } );
+
+	unsigned char out_data_text[1024];
+	BitfieldDefaultsMulti loaded;
+
+	EXPECT_DL_ERR_OK(dl_txt_pack(Ctx, text_data, out_data_text, sizeof(out_data_text), 0x0));
+	EXPECT_DL_ERR_OK(dl_instance_load(Ctx, BitfieldDefaultsMulti::TYPE_ID, &loaded, sizeof(BitfieldDefaultsMulti), out_data_text, sizeof(out_data_text), 0x0));
+
+	EXPECT_EQ(1, loaded.f1);
+	EXPECT_EQ(1, loaded.f2);
+	EXPECT_EQ(0, loaded.f3);
+	EXPECT_EQ(1, loaded.f4);
+	EXPECT_EQ(1, loaded.f5);
+	EXPECT_EQ(3, loaded.f6);
+}
+
 TEST_F(DLText, default_value_enum)
 {
 	const char* text_data = STRINGIFY( { "DefaultEnum" : {} } );

--- a/tests/dl_tests_txt.cpp
+++ b/tests/dl_tests_txt.cpp
@@ -194,6 +194,24 @@ TEST_F(DLText, default_value_struct)
 	EXPECT_EQ(37u, loaded.Struct.Int2);
 }
 
+TEST_F(DLText, default_value_bitfield)
+{
+	const char* text_data = STRINGIFY( { "BitfieldDefaultsMulti" : {} } );
+
+	unsigned char out_data_text[1024];
+	BitfieldDefaultsMulti loaded;
+
+	EXPECT_DL_ERR_OK(dl_txt_pack(Ctx, text_data, out_data_text, sizeof(out_data_text), 0x0));
+	EXPECT_DL_ERR_OK(dl_instance_load(Ctx, BitfieldDefaultsMulti::TYPE_ID, &loaded, sizeof(BitfieldDefaultsMulti), out_data_text, sizeof(out_data_text), 0x0));
+
+	EXPECT_EQ(0, loaded.f1);
+	EXPECT_EQ(1, loaded.f2);
+	EXPECT_EQ(0, loaded.f3);
+	EXPECT_EQ(1, loaded.f4);
+	EXPECT_EQ(2, loaded.f5);
+	EXPECT_EQ(3, loaded.f6);
+}
+
 TEST_F(DLText, default_value_enum)
 {
 	const char* text_data = STRINGIFY( { "DefaultEnum" : {} } );
@@ -695,10 +713,10 @@ static T* dl_txt_test_pack_text(dl_ctx_t Ctx, const char* txt, unsigned char* un
 {
     unsigned char out_text_data[4096];
     EXPECT_DL_ERR_OK( dl_txt_pack( Ctx, txt, out_text_data, DL_ARRAY_LENGTH(out_text_data), 0x0 ) );
-    
+
     memset( unpack_buffer, 0x0, unpack_buffer_size );
     EXPECT_DL_ERR_OK( dl_instance_load( Ctx, T::TYPE_ID, unpack_buffer, unpack_buffer_size, out_text_data, DL_ARRAY_LENGTH(out_text_data), 0x0 ) );
-    
+
     return (T*)unpack_buffer;
 }
 
@@ -798,7 +816,7 @@ TEST_F( DLText, accept_trailing_comma_array_i16 )
 
 TEST_F( DLText, accept_trailing_comma_array_i32 )
 {
-    unsigned char unpack_buffer[1024]; 
+    unsigned char unpack_buffer[1024];
     i32Array* arr = dl_txt_test_pack_text<i32Array>(Ctx, STRINGIFY( { i32Array : { arr : [1,2,3,] } } ), unpack_buffer, sizeof(unpack_buffer));
     int32_t expect[] = {1,2,3};
     EXPECT_ARRAY_EQ(3, arr->arr.data, expect);
@@ -806,7 +824,7 @@ TEST_F( DLText, accept_trailing_comma_array_i32 )
 
 TEST_F( DLText, accept_trailing_comma_array_i64 )
 {
-    unsigned char unpack_buffer[1024]; 
+    unsigned char unpack_buffer[1024];
     i64Array* arr = dl_txt_test_pack_text<i64Array>(Ctx, STRINGIFY( { i64Array : { arr : [1,2,3,] } } ), unpack_buffer, sizeof(unpack_buffer));
     int64_t expect[] = {1,2,3};
     EXPECT_ARRAY_EQ(3, arr->arr.data, expect);

--- a/tests/unittest.tld
+++ b/tests/unittest.tld
@@ -1,8 +1,8 @@
 {
 	"module" : "unit_test",
-	
+
 	"usercode" : "#include \"../../tests/dl_test_included.h\"",
-	
+
 	"enums" : {
 		"TestEnum1" : {
 			"TESTENUM1_VALUE1" : 0,
@@ -23,10 +23,10 @@
 			"MULTI_ALIAS2" : { "value" : 8, "aliases" : [ "alias4" ] }
 		}
 	},
-	
+
 	"types" : {
 		"unused" : { "members" : [ { "name" : "member",  "type" : "int32", "comment" : "only used in unittests to check for errors" } ] },
-		
+
 		"Pods" : {
 			"members" : [
 				{ "name" : "i8",  "type" : "int8"   },
@@ -56,7 +56,7 @@
         "ptrArray"  : { "members" : [ { "name" : "arr",  "type" : "Pods*[]"  } ] },
         "enumArray" : { "members" : [ { "name" : "arr",  "type" : "TestEnum1[]" } ] }
 	},
-	
+
 	"unions" : {
 		"test_union_simple" : {
 			"members" : [
@@ -66,31 +66,31 @@
 			]
 		}
 	},
-	
+
 	"types" : {
 		"MorePods"     : { "members" : [ { "name" : "Pods1", "type" : "Pods"  },  { "name" : "Pods2", "type" : "Pods" }   ] },
 		"Pods2"        : { "members" : [ { "name" : "Int1",  "type" : "uint32" }, { "name" : "Int2",  "type" : "uint32" } ] },
 		"Pod2InStruct" : { "members" : [ { "name" : "Pod1",  "type" : "Pods2" },  { "name" : "Pod2",  "type" : "Pods2" }  ] },
-		
-		"Pod2InStructInStruct"        : { "members" : [ { "name" : "p2struct", "type" : "Pod2InStruct" } ] }, 
+
+		"Pod2InStructInStruct"        : { "members" : [ { "name" : "p2struct", "type" : "Pod2InStruct" } ] },
 		"WithInlineArray"             : { "members" : [ { "name" : "Array",    "type" : "uint32[3]" } ] },
 		"WithInlineStructArray"       : { "members" : [ { "name" : "Array",    "type" : "Pods2[3]" } ] },
 		"WithInlineStructStructArray" : { "members" : [ { "name" : "Array",    "type" : "WithInlineStructArray[2]" } ] },
-		
+
 		"SubString"                   : { "members" : [ { "name" : "Str",      "type" : "string" } ] },
 		"InlineArrayWithSubString"    : { "members" : [ { "name" : "Array",    "type" : "SubString[2]" } ] },
-		
-		"PodArray1"    : { "members" : [ { "name" : "u32_arr", "type" : "uint32[]" } ] }, 
-		"PodArray2"    : { "members" : [ { "name" : "sub_arr", "type" : "PodArray1[]" } ] }, 
-		
+
+		"PodArray1"    : { "members" : [ { "name" : "u32_arr", "type" : "uint32[]" } ] },
+		"PodArray2"    : { "members" : [ { "name" : "sub_arr", "type" : "PodArray1[]" } ] },
+
 		"StructArray1" : { "members" : [ { "name" : "Array", "type" : "Pods2[]" }  ] },
-		
+
 		"Strings"           : { "members" : [ { "name" : "Str1", "type" : "string" }, { "name" : "Str2", "type" : "string" } ] },
 		"StringInlineArray" : { "members" : [ { "name" : "Strings", "type" : "string[3]" } ] },
 		"StringArray"       : { "members" : [ { "name" : "Strings", "type" : "string[]" } ] },
-		
+
 		"TestBits" : {
-			"members" : [ 
+			"members" : [
 				{ "name" : "Bit1", "type" : "bitfield:1" },
 				{ "name" : "Bit2", "type" : "bitfield:2" },
 				{ "name" : "Bit3", "type" : "bitfield:3" },
@@ -100,14 +100,14 @@
 				{ "name" : "Bit6", "type" : "bitfield:3" }
 			]
 		},
-		
+
 		"MoreBits" : {
-			"members" : [ 
+			"members" : [
 				{ "name" : "Bit1", "type" : "bitfield:15" },
 				{ "name" : "Bit2", "type" : "bitfield:7" }
 			]
 		},
-		
+
 		"BitBitfield64" : {
 			"members" : [
 				{ "name" : "Package",  "type" : "bitfield:7" },
@@ -116,21 +116,21 @@
 				{ "name" : "FileHash", "type" : "bitfield:32" }
 			]
 		},
-		
+
 		"SimplePtr" : {
-			"members" : [ 
+			"members" : [
 				{ "name" : "Ptr1", "type" : "Pods*" },
-				{ "name" : "Ptr2", "type" : "Pods*" } 
-			] 
+				{ "name" : "Ptr2", "type" : "Pods*" }
+			]
 		},
-		
+
 		"PtrChain" : {
 			"members" : [
 				{ "name" : "Int",  "type" : "uint32" },
 				{ "name" : "Next", "type" : "PtrChain*" }
 			]
 		},
-		
+
 		"DoublePtrChain" : {
 			"members" : [
 				{ "name" : "Int",  "type" : "uint32" },
@@ -138,26 +138,26 @@
 				{ "name" : "Prev", "type" : "DoublePtrChain*" }
 			]
 		},
-		
+
 		"inline_ptr_array" : {
 			"members" : [
 				{ "name" : "arr", "type" : "Pods2*[3]" }
 			]
 		},
-		
+
 		"ptr_array" : {
 			"members" : [
 				{ "name" : "arr", "type" : "Pods2*[]" }
 			]
 		},
-		
+
 		"A128BitAlignedType" : { "align" : 128, "members" : [ { "name" : "Int",  "type" : "uint32" } ] },
-		
+
 		"TestingEnum" : { "members" : [ { "name" : "TheEnum", "type" : "TestEnum1" } ] },
-		
+
 		"InlineArrayEnum" : { "members" : [ { "name" : "EnumArr", "type" : "TestEnum2[4]" } ] },
 		"ArrayEnum"       : { "members" : [ { "name" : "EnumArr", "type" : "TestEnum2[]" } ] },
-		
+
 		// testing a comment here
 		"PodsDefaults" : {
 			"members" : [
@@ -174,6 +174,16 @@
 			]
 		},
 
+		"BitfieldDefaultsMulti" : {
+			"members" : [
+				{ "name": "f1", "type" : "bitfield:1", "default" : 0 },
+				{ "name": "f2", "type" : "bitfield:1", "default" : 1 },
+				{ "name": "f3", "type" : "bitfield:2", "default" : 0 },
+				{ "name": "f4", "type" : "bitfield:2", "default" : 1 },
+				{ "name": "f5", "type" : "bitfield:2", "default" : 2 },
+				{ "name": "f6", "type" : "bitfield:2", "default" : 3 }
+			]
+		},
 		/*
 			And a multiline comment here
 		*/
@@ -181,7 +191,7 @@
 		"DefaultEnum" :     { "members" : [ { "name" : "Enum",   "type" : "TestEnum1", "default" : "TESTENUM1_VALUE3"           } ] },
 		"DefaultStruct" :   { "members" : [ { "name" : "Struct", "type" : "Pods2",     "default" : { "Int1" : 13, "Int2" : 37 } } ] },
 		"DefaultPtr"  :     { "members" : [ { "name" : "Ptr",    "type" : "Pods*",     "default" : null                         } ] },
-		
+
 		/**
 			another comment
 		*/
@@ -202,7 +212,7 @@
 		"DefaultArrayStr"  :    { "members" : [ { "name" : "Arr",  "type" : "string[]",    "default" : [ "cow", "bells", "are", "cool" ] } ] },
 		"DefaultArrayEnum" :    { "members" : [ { "name" : "Arr",  "type" : "TestEnum1[]", "default" : [ "TESTENUM1_VALUE3",
 		                                                                                                 "TESTENUM1_VALUE1",
-		                                                                                                 "TESTENUM1_VALUE2", 
+		                                                                                                 "TESTENUM1_VALUE2",
 		                                                                                                 "TESTENUM1_VALUE4" ] } ] },
 		"DefaultArrayArray" : { "members" : [ {
 									"name" : "Arr",
@@ -211,7 +221,7 @@
 								  }
 	                            ] },
 
-		"DefaultWithOtherDataBefore" : { 
+		"DefaultWithOtherDataBefore" : {
 			"members" : [
 				{ "name" : "t1",  "type" : "string" },
 				{ "name" : "Str", "type" : "string", "default" : "who" }
@@ -226,25 +236,25 @@
 				{ "name" : "e4", "type" : "multi_alias_enum" }
 			]
 		},
-		
+
 		"BugTest4" : {
 			"members" : [
 				{ "name" : "struct_with_str_arr", "type" : "StringArray[]" }
 			]
 		},
-		
+
 		"PtrHolder" : { "members" : [ { "name" : "ptr", "type" : "Pods2*"      } ] },
 		"PtrArray"  : { "members" : [ { "name" : "arr", "type" : "PtrHolder[]" } ] },
-		
+
 		"circular_array_ptr_holder" : { "members" : [ { "name" : "ptr", "type" : "circular_array*" } ] },
-		"circular_array" : { 
-			"members" : [ 
+		"circular_array" : {
+			"members" : [
 				{ "name" : "val", "type" : "uint16" }, // alignment-bug here, put this member after array and it will fail!
-				{ "name" : "arr", "type" : "circular_array_ptr_holder[]" } 
+				{ "name" : "arr", "type" : "circular_array_ptr_holder[]" }
 			]
 		},
-		
-		
+
+
 		"str_before_array_bug_arr_type" : { "members" : [ { "name" : "str", "type" : "string" } ] },
 		"str_before_array_bug" : {
 		    "members" : [
@@ -252,7 +262,7 @@
 		        { "name" : "arr", "type": "str_before_array_bug_arr_type[]"}
 		    ]
 		},
-		
+
 		"bug_array_alignment_struct" : {
 			"members" : [
 				{ "name" : "type",         "type" : "uint32" },
@@ -260,33 +270,33 @@
 				{ "name" : "used_sources", "type" : "uint32" }
 			]
 		},
-		
+
 		"bug_array_alignment" : {
 			"members" : [
 				{ "name" : "components", "type" : "bug_array_alignment_struct[]" }
 			]
 		},
-		
+
 		"test_array_pad_1" : {
 			"members" : [
 				{ "name" : "ptr",          "type" : "uint8[]" },
 				{ "name" : "type",         "type" : "uint32"  }
 			]
 		},
-		
+
 		"test_array_pad" : {
 			"members" : [
 				{ "name" : "components", "type" : "test_array_pad_1[]" }
 			]
 		},
-		
+
 		"test_inline_array_size_from_enum" : {
 			"members" : [
 				{ "name" : "arr1", "type" : "int32[TESTENUM2_VALUE1]" },
 				{ "name" : "arr2", "type" : "int32[TESTENUM1_VALUE4]" }
 			]
 		},
-		
+
 		"test_inline_array_of_unions" : {
 			"members" : [
 				{ "name" : "arr", "type" : "test_union_simple[3]" }


### PR DESCRIPTION
Previously, having defaults for bitfields did not yield the correct result. This was because bitfields can be sub-byte sized and previous implementation of defaults did not take this into consideration.

I'm not 100% certain that I've done everything correct so please review the code in dl_txt_pack before admitting the pull request.