### PR TITLE
Bad count on pointer patching dynamic arrays.

### DIFF
--- a/src/dl_patch_ptr.cpp
+++ b/src/dl_patch_ptr.cpp
@@ -175,7 +175,7 @@ static void dl_internal_patch_member( dl_ctx_t              ctx,
 
 			union { uint8_t* src; uint32_t ptr; };
 			src = member_data + sizeof( void* );
-			uint32_t count = *src;
+			uint32_t count = *(uint32_t*)src;
 
 			if( count != 0 )
 			{

--- a/tests/dl_tests_base.cpp
+++ b/tests/dl_tests_base.cpp
@@ -143,8 +143,8 @@ void convert_inplace_test_do_it( dl_ctx_t       dl_ctx,        dl_typeid_t type,
 		*out_buffer = (unsigned char*)malloc(*out_size + 1);
 		memset(*out_buffer, 0xFE, *out_size + 1);
 
-		memcpy( *out_buffer, convert_buffer, convert_size );
-		EXPECT_DL_ERR_OK( dl_convert_inplace( dl_ctx, type, *out_buffer, convert_size, DL_ENDIAN_HOST, sizeof(void*), out_size ) );
+		EXPECT_DL_ERR_OK( dl_convert_inplace( dl_ctx, type, convert_buffer, convert_size, DL_ENDIAN_HOST, sizeof(void*), out_size ) );
+		memcpy(*out_buffer, convert_buffer, *out_size);
 	}
 
 	free(convert_buffer);

--- a/tests/dl_tests_base.cpp
+++ b/tests/dl_tests_base.cpp
@@ -7,14 +7,14 @@
 
 void pack_text_test::do_it( dl_ctx_t       dl_ctx,       dl_typeid_t type,
 					   unsigned char* store_buffer, size_t      store_size,
-					   unsigned char* out_buffer,   size_t*     out_size )
+					   unsigned char** out_buffer,   size_t*     out_size )
 {
 	// unpack binary to txt
-	char text_buffer[2048];
-	memset(text_buffer, 0xFE, sizeof(text_buffer));
-
 	size_t text_size = 0;
 	EXPECT_DL_ERR_OK( dl_txt_unpack_calc_size( dl_ctx, type, store_buffer, store_size, &text_size ) );
+	char *text_buffer = (char*)malloc(text_size+1);
+	memset(text_buffer, 0xFE, text_size+1);
+
 	EXPECT_DL_ERR_OK( dl_txt_unpack( dl_ctx, type, store_buffer, store_size, text_buffer, text_size, 0x0 ) );
 	EXPECT_EQ( (unsigned char)0xFE, (unsigned char)text_buffer[text_size] ); // no overwrite on the generated text plox!
 
@@ -22,16 +22,21 @@ void pack_text_test::do_it( dl_ctx_t       dl_ctx,       dl_typeid_t type,
 
 	// pack txt to binary
 	EXPECT_DL_ERR_OK( dl_txt_pack_calc_size( dl_ctx, text_buffer, out_size ) );
-	EXPECT_DL_ERR_OK( dl_txt_pack( dl_ctx, text_buffer, out_buffer, *out_size, 0x0 ) );
+	*out_buffer = (unsigned char*)malloc(*out_size+1);
+	memset(*out_buffer, 0xFE, *out_size+1);
+
+	EXPECT_DL_ERR_OK( dl_txt_pack( dl_ctx, text_buffer, *out_buffer, *out_size, 0x0 ) );
+
+	free(text_buffer);
 }
 
 void inplace_load_test::do_it( dl_ctx_t       dl_ctx,       dl_typeid_t type,
 					   	   	   unsigned char* store_buffer, size_t      store_size,
-							   unsigned char* out_buffer,   size_t*     out_size )
+							   unsigned char** out_buffer,   size_t*     out_size )
 {
 	// copy stored instance into temp-buffer
-	unsigned char inplace_buffer[4096];
-	memset( inplace_buffer, 0xFE, DL_ARRAY_LENGTH(inplace_buffer) );
+	unsigned char *inplace_buffer = (unsigned char*)malloc(store_size+1);
+	memset( inplace_buffer, 0xFE, store_size+1 );
 	memcpy( inplace_buffer, store_buffer, store_size );
 
 	// load inplace
@@ -40,23 +45,27 @@ void inplace_load_test::do_it( dl_ctx_t       dl_ctx,       dl_typeid_t type,
 	EXPECT_DL_ERR_OK( dl_instance_load_inplace( dl_ctx, type, inplace_buffer, store_size, &loaded_instance, &consumed ));
 
 	EXPECT_EQ( store_size, consumed );
-	EXPECT_EQ( (unsigned char)0xFE, (unsigned char)inplace_buffer[store_size + 1] ); // no overwrite by inplace load!
+	EXPECT_EQ( (unsigned char)0xFE, (unsigned char)inplace_buffer[store_size] ); // no overwrite by inplace load!
 
 	// store to out-buffer
 	EXPECT_DL_ERR_OK( dl_instance_calc_size( dl_ctx, type, loaded_instance, out_size ) );
-	EXPECT_DL_ERR_OK( dl_instance_store( dl_ctx, type, loaded_instance, out_buffer, *out_size, 0x0 ) );
+	*out_buffer = (unsigned char*)malloc(*out_size + 1);
+	memset(*out_buffer, 0xFE, *out_size + 1);
+
+	EXPECT_DL_ERR_OK( dl_instance_store( dl_ctx, type, loaded_instance, *out_buffer, *out_size, 0x0 ) );
+	free(inplace_buffer);
 }
 
 void convert_test_do_it( dl_ctx_t       dl_ctx,        dl_typeid_t type,
 						 unsigned char* store_buffer,  size_t      store_size,
-						 unsigned char* out_buffer,    size_t*     out_size,
+						 unsigned char** out_buffer,    size_t*     out_size,
 						 unsigned int   conv_ptr_size, dl_endian_t conv_endian )
 {
 	// calc size to convert
-	unsigned char convert_buffer[2048];
-	memset(convert_buffer, 0xFE, sizeof(convert_buffer));
 	size_t convert_size = 0;
 	EXPECT_DL_ERR_OK( dl_convert_calc_size( dl_ctx, type, store_buffer, store_size, conv_ptr_size, &convert_size ) );
+	unsigned char *convert_buffer = (unsigned char*)malloc(convert_size+1);
+	memset(convert_buffer, 0xFE, convert_size+1);
 
 	// convert to other pointer size
 	EXPECT_DL_ERR_OK( dl_convert( dl_ctx, type, store_buffer, store_size, convert_buffer, convert_size, conv_endian, conv_ptr_size, 0x0 ) );
@@ -65,14 +74,17 @@ void convert_test_do_it( dl_ctx_t       dl_ctx,        dl_typeid_t type,
 
 	// calc size to re-convert to host pointer size
 	EXPECT_DL_ERR_OK( dl_convert_calc_size( dl_ctx, type, convert_buffer, convert_size, sizeof(void*), out_size ) );
+	*out_buffer = (unsigned char*)malloc(*out_size + 1);
+	memset(*out_buffer, 0xFE, *out_size + 1);
 
 	// re-convert to host pointer size
-	EXPECT_DL_ERR_OK( dl_convert( dl_ctx, type, convert_buffer, convert_size, out_buffer, *out_size, DL_ENDIAN_HOST, sizeof(void*), 0x0 ) );
+	EXPECT_DL_ERR_OK( dl_convert( dl_ctx, type, convert_buffer, convert_size, *out_buffer, *out_size, DL_ENDIAN_HOST, sizeof(void*), 0x0 ) );
+	free(convert_buffer);
 }
 
 void convert_inplace_test_do_it( dl_ctx_t       dl_ctx,        dl_typeid_t type,
         						 unsigned char* store_buffer,  size_t      store_size,
-								 unsigned char* out_buffer,    size_t*     out_size,
+								 unsigned char** out_buffer,    size_t*     out_size,
 								 unsigned int   conv_ptr_size, dl_endian_t conv_endian )
 {
 	/*
@@ -86,15 +98,17 @@ void convert_inplace_test_do_it( dl_ctx_t       dl_ctx,        dl_typeid_t type,
 			do the supported operation inplace.
 	*/
 
-	unsigned char convert_buffer[2048];
-	memset( convert_buffer, 0xFE, sizeof(convert_buffer) );
 	size_t convert_size = 0;
+	EXPECT_DL_ERR_OK(dl_convert_calc_size(dl_ctx, type, store_buffer, store_size, conv_ptr_size, &convert_size));
+	size_t convert_buffer_size = store_size > convert_size ? store_size + 1 : convert_size + 1;
+	unsigned char *convert_buffer = (unsigned char*)malloc(convert_buffer_size);
+	memset( convert_buffer, 0xFE, convert_buffer_size);
 
 	if( conv_ptr_size <= sizeof(void*) )
 	{
 		memcpy( convert_buffer, store_buffer, store_size );
 		EXPECT_DL_ERR_OK( dl_convert_inplace( dl_ctx, type, convert_buffer, store_size, conv_endian, conv_ptr_size, &convert_size ) );
-		memset( convert_buffer + convert_size, 0xFE, sizeof(convert_buffer) - convert_size );
+		memset( convert_buffer + convert_size, 0xFE, store_size - convert_size);
 	}
 	else
 	{
@@ -114,16 +128,24 @@ void convert_inplace_test_do_it( dl_ctx_t       dl_ctx,        dl_typeid_t type,
 	if( conv_ptr_size < sizeof(void*))
 	{
 		// check that error is correct
-		EXPECT_DL_ERR_EQ( DL_ERROR_UNSUPPORTED_OPERATION, dl_convert_inplace( dl_ctx, type, convert_buffer, store_size, DL_ENDIAN_HOST, sizeof(void*), out_size ) );
+		EXPECT_DL_ERR_EQ( DL_ERROR_UNSUPPORTED_OPERATION, dl_convert_inplace( dl_ctx, type, convert_buffer, convert_size, DL_ENDIAN_HOST, sizeof(void*), out_size ) );
 
 		// convert with ordinary convert
 		EXPECT_DL_ERR_OK( dl_convert_calc_size( dl_ctx, type, convert_buffer, convert_size, sizeof(void*), out_size ) );
-		EXPECT_DL_ERR_OK( dl_convert( dl_ctx, type, convert_buffer, convert_size, out_buffer, *out_size, DL_ENDIAN_HOST, sizeof(void*), 0x0 ) );
+		*out_buffer = (unsigned char*)malloc(*out_size + 1);
+		memset(*out_buffer, 0xFE, *out_size + 1);
+
+		EXPECT_DL_ERR_OK( dl_convert( dl_ctx, type, convert_buffer, convert_size, *out_buffer, *out_size, DL_ENDIAN_HOST, sizeof(void*), 0x0 ) );
 	}
 	else
 	{
-		memcpy( out_buffer, convert_buffer, convert_size );
-		EXPECT_DL_ERR_OK( dl_convert_inplace( dl_ctx, type, out_buffer, convert_size, DL_ENDIAN_HOST, sizeof(void*), out_size ) );
-		memset( out_buffer + *out_size, 0xFE, OUT_BUFFER_SIZE - *out_size );
+		EXPECT_DL_ERR_OK(dl_convert_calc_size(dl_ctx, type, convert_buffer, convert_size, sizeof(void*), out_size));
+		*out_buffer = (unsigned char*)malloc(*out_size + 1);
+		memset(*out_buffer, 0xFE, *out_size + 1);
+
+		memcpy( *out_buffer, convert_buffer, convert_size );
+		EXPECT_DL_ERR_OK( dl_convert_inplace( dl_ctx, type, *out_buffer, convert_size, DL_ENDIAN_HOST, sizeof(void*), out_size ) );
 	}
+
+	free(convert_buffer);
 }

--- a/tests/dl_tests_base.h
+++ b/tests/dl_tests_base.h
@@ -99,7 +99,7 @@ struct DLBase : public DL
 			EXPECT_INSTANCE_INFO( store_buffer, store_size, sizeof(void*), DL_ENDIAN_HOST, type );
 			EXPECT_EQ( 0xFE, store_buffer[store_size] ); // no overwrite on the calculated size plox!
 
-			unsigned char *out_buffer = nullptr;
+			unsigned char *out_buffer = 0x0;
 			size_t out_size;
 
 			// Moved memset out-buffer to inside do_it();, which allocates bytes + 1 and memsets it to 0xfe

--- a/tests/dl_tests_base.h
+++ b/tests/dl_tests_base.h
@@ -68,12 +68,12 @@ struct DLBase : public DL
 	unsigned char *load_buffer;
 
 	DLBase() 
-		: store_buffer(nullptr)
+		: store_buffer(0x0)
 	{
 
 	}
 	virtual ~DLBase() {
-		if (store_buffer != nullptr) {
+		if (store_buffer != 0x0) {
 			free(store_buffer);
 		}
 	}

--- a/tests/dl_tests_base.h
+++ b/tests/dl_tests_base.h
@@ -12,26 +12,25 @@
 	EXPECT_EQ( exp_type,     inst_info.root_type ); \
 }
 
-const unsigned int OUT_BUFFER_SIZE = 2048;
 const unsigned int TEST_REPS       = 1; // number of times to repeate tests internally, use for profiling etc.
 
 struct pack_text_test
 {
 	static void do_it( dl_ctx_t       dl_ctx,       dl_typeid_t type,
 					   unsigned char* store_buffer, size_t      store_size,
-					   unsigned char* out_buffer,   size_t*     out_size );
+					   unsigned char** out_buffer,   size_t*     out_size );
 };
 
 struct inplace_load_test
 {
 	static void do_it( dl_ctx_t       dl_ctx,       dl_typeid_t type,
 					   unsigned char* store_buffer, size_t      store_size,
-					   unsigned char* out_buffer,   size_t*     out_size );
+					   unsigned char** out_buffer,   size_t*     out_size );
 };
 
 void convert_test_do_it( dl_ctx_t       dl_ctx,        dl_typeid_t type,
 						 unsigned char* store_buffer,  size_t      store_size,
-						 unsigned char* out_buffer,    size_t*     out_size,
+						 unsigned char** out_buffer,    size_t*     out_size,
 						 unsigned int   conv_ptr_size, dl_endian_t conv_endian );
 
 template<unsigned int conv_ptr_size, dl_endian_t conv_endian>
@@ -40,7 +39,7 @@ struct convert_test
 
 	static void do_it( dl_ctx_t       dl_ctx,       dl_typeid_t type,
 					   unsigned char* store_buffer, size_t      store_size,
-					   unsigned char* out_buffer,   size_t*     out_size )
+					   unsigned char** out_buffer,   size_t*     out_size )
 	{
 		convert_test_do_it( dl_ctx, type, store_buffer, store_size, out_buffer, out_size, conv_ptr_size, conv_endian );
 	}
@@ -48,7 +47,7 @@ struct convert_test
 
 void convert_inplace_test_do_it( dl_ctx_t       dl_ctx,        dl_typeid_t type,
         						 unsigned char* store_buffer,  size_t      store_size,
-								 unsigned char* out_buffer,    size_t*     out_size,
+								 unsigned char** out_buffer,    size_t*     out_size,
 								 unsigned int   conv_ptr_size, dl_endian_t conv_endian );
 
 template<unsigned int conv_ptr_size, dl_endian_t conv_endian>
@@ -56,7 +55,7 @@ struct convert_inplace_test
 {
 	static void do_it( dl_ctx_t       dl_ctx,       dl_typeid_t type,
 			           unsigned char* store_buffer, size_t      store_size,
-			           unsigned char* out_buffer,   size_t*     out_size )
+			           unsigned char** out_buffer,   size_t*     out_size )
 	{
 		convert_inplace_test_do_it( dl_ctx, type, store_buffer, store_size, out_buffer, out_size, conv_ptr_size, conv_endian );
 	}
@@ -65,42 +64,58 @@ struct convert_inplace_test
 template <typename T>
 struct DLBase : public DL
 {
-	virtual ~DLBase() {}
+	unsigned char *store_buffer;
+	unsigned char *load_buffer;
+
+	DLBase() 
+		: store_buffer(nullptr)
+	{
+
+	}
+	virtual ~DLBase() {
+		if (store_buffer != nullptr) {
+			free(store_buffer);
+		}
+	}
+
+	size_t calculate_unpack_size(dl_typeid_t type, void *pack_me) {
+		size_t unpack_me_size = 0;
+		dl_instance_calc_size(this->Ctx, type, pack_me, &unpack_me_size);
+		return unpack_me_size;
+	}
 
 	void do_the_round_about( dl_typeid_t type, void* pack_me, void* unpack_me, size_t unpack_me_size )
 	{
 		dl_ctx_t dl_ctx = this->Ctx;
-
+		// calc size of stored instance
+		size_t store_size = 0;
+		EXPECT_DL_ERR_OK(dl_instance_calc_size(dl_ctx, type, pack_me, &store_size));
+		store_buffer = (unsigned char*)malloc(store_size+1);
 		for( unsigned int i = 0; i < TEST_REPS; ++i )
 		{
-			unsigned char store_buffer[1024];
-			memset(store_buffer, 0xFE, sizeof(store_buffer));
-
-			// calc size of stored instance
-			size_t store_size = 0;
-			EXPECT_DL_ERR_OK( dl_instance_calc_size( dl_ctx, type, pack_me, &store_size ) );
-
+			memset(store_buffer, 0xFE, store_size+1);
 			// store instance to binary
 			EXPECT_DL_ERR_OK( dl_instance_store( dl_ctx, type, pack_me, store_buffer, store_size, 0x0 ) );
 			EXPECT_INSTANCE_INFO( store_buffer, store_size, sizeof(void*), DL_ENDIAN_HOST, type );
 			EXPECT_EQ( 0xFE, store_buffer[store_size] ); // no overwrite on the calculated size plox!
 
-			unsigned char out_buffer[OUT_BUFFER_SIZE];
-			memset( out_buffer, 0xFE, sizeof(out_buffer) );
+			unsigned char *out_buffer = nullptr;
 			size_t out_size;
 
-			T::do_it( dl_ctx, type, store_buffer, store_size, out_buffer, &out_size );
+			// Moved memset out-buffer to inside do_it();, which allocates bytes + 1 and memsets it to 0xfe
+			T::do_it( dl_ctx, type, store_buffer, store_size, &out_buffer, &out_size );
 
 			EXPECT_EQ( (unsigned char)0xFE, out_buffer[out_size] ); // no overwrite when packing text plox!
-
+			
 			// out instance should have correct format
 			EXPECT_INSTANCE_INFO( out_buffer, out_size, sizeof(void*), DL_ENDIAN_HOST, type );
 
 			size_t consumed = 0;
-			// load binary
 			EXPECT_DL_ERR_OK( dl_instance_load( dl_ctx, type, unpack_me, unpack_me_size, out_buffer, out_size, &consumed ) );
 
 			EXPECT_EQ( out_size, consumed );
+
+			free(out_buffer);
 		}
 	}
 };

--- a/tests/unittest2.tld
+++ b/tests/unittest2.tld
@@ -1,23 +1,23 @@
 {
 	"module" : "unit_test_2",
-	
+
 	"types" : {
 		"BugTest1_InArray" : { "members" : [ { "name" : "u64_1", "type" : "uint64" },
 											 { "name" : "u64_2", "type" : "uint64" },
 											 { "name" : "u16",   "type" : "uint16" } ] },
-											 
+
 		"BugTest1" : { "members" : [ { "name" : "Arr", "type" : "BugTest1_InArray[]" } ] },
-		
+
 		"BugTest2_WithMat" : {
 			"members" : [
 				{ "name" : "iSubModel", "type" : "uint32" },
 				{ "name" : "Transform", "type" : "fp32[16]" }
 			]
 		},
-                         
+
 		"BugTest2" : { "members" : [ { "name" : "Instances", "type" : "BugTest2_WithMat[]" } ] },
 
-		// testing bug where struct first in struct with ptr in substruct will not get patched on load. 		
+		// testing bug where struct first in struct with ptr in substruct will not get patched on load.
 		"BugTest3_StructWithPtr" : { "members" : [ { "name" : "arr", "type" : "uint32[]" } ] },
 		"BugTest3" :               { "members" : [ { "name" : "sub", "type" : "BugTest3_StructWithPtr" } ] },
 
@@ -35,19 +35,29 @@
 				{ "name" : "sub", "type" : "bug_with_substr_2" }
 			]
 		},
-		
-		"vec3_test" : { 
+
+		"vec3_test" : {
 			"extern" : true,
-			"members" : [ 
+			"members" : [
 				{ "name" : "x", "type" : "fp32" },
 				{ "name" : "y", "type" : "fp32" },
-				{ "name" : "z", "type" : "fp32" } 
+				{ "name" : "z", "type" : "fp32" }
 			]
 		},
 		"alias_test" : {
 			"members" : [
 				{ "name" : "m1", "type" : "vec3_test" },
 				{ "name" : "m2", "type" : "vec3_test" }
+			]
+		},
+		"complex_member" : {
+			"members" : [
+				{ "name" : "dynamic_arr", "type" : "uint32[]" }
+			]
+		},
+		"big_array_test" : {
+			"members" : [
+				{ "name" : "members", "type" : "complex_member[]" }
 			]
 		}
 	}


### PR DESCRIPTION
The issue is that when pointer patching goes through dynamic arrays, it fetches the count by using uint32_t count = *src; where src is an uint8-pointer.

In order to test this, the array that we need to test on needs to be more than UINT8_MAX count, and that array needs to contain pointers that needs patching in order to encounter an actual issue with the bug.

In order to facilitate the bug-testing I had to rewrite a lot of unit-test functionality to be dynamically allocated buffers with malloc() instead of static buffers. This can probably be cleaned up a bit and optimized.