### PR TITLE
Added allocator to dl_util functions.

### DIFF
--- a/include/dl/dl_util.h
+++ b/include/dl/dl_util.h
@@ -20,6 +20,7 @@
 extern "C" {
 #endif  // __cplusplus
 
+struct dl_allocator;
 /*
 	Enum: dl_util_file_type_t
 		Enumeration of possible file types that can be read by util-functions.
@@ -52,13 +53,15 @@ typedef enum
 		filetype     - Type of file to read, see dl_util_file_type_t.
 		out_instance - Pointer to fill with read instance.
 		out_type     - TypeID of instance found in file, can be set to 0x0.
+		allocator 	 - Allocator for doing temp file allocations
 
 	Returns:
 		DL_ERROR_OK on success.
 */
 dl_error_t dl_util_load_from_file( dl_ctx_t    dl_ctx,       dl_typeid_t         type,
 								   const char* filename,     dl_util_file_type_t filetype,
-								   void**      out_instance, dl_typeid_t*        out_type );
+								   void**      out_instance, dl_typeid_t*        out_type,
+								   dl_allocator *allocator = 0x0 );
 
 /*
 	Function: dl_util_load_from_stream
@@ -71,13 +74,14 @@ dl_error_t dl_util_load_from_file( dl_ctx_t    dl_ctx,       dl_typeid_t        
 		more.
 
 	Parameters:
-		dl_ctx         - Context to use for operations.
-		type           - Type expected to be found in file, set to 0 if not known.
-		stream         - Open stream to load from.
-		filetype       - Type of file to read, see dl_util_file_type_t.
-		out_instance   - Pointer to fill with read instance.
-		out_type       - TypeID of instance found in file, can be set to 0x0.
-		consumed_bytes - Number of bytes read from stream.
+		dl_ctx         	- Context to use for operations.
+		type           	- Type expected to be found in file, set to 0 if not known.
+		stream         	- Open stream to load from.
+		filetype       	- Type of file to read, see dl_util_file_type_t.
+		out_instance   	- Pointer to fill with read instance.
+		out_type       	- TypeID of instance found in file, can be set to 0x0.
+		consumed_bytes 	- Number of bytes read from stream.
+		allocator 		- Allocator for doing temp file allocations
 
 	Returns:
 		DL_ERROR_OK on success.
@@ -85,7 +89,7 @@ dl_error_t dl_util_load_from_file( dl_ctx_t    dl_ctx,       dl_typeid_t        
 dl_error_t dl_util_load_from_stream( dl_ctx_t dl_ctx,       dl_typeid_t         type,
 									 FILE*    stream,       dl_util_file_type_t filetype,
 									 void**   out_instance, dl_typeid_t*        out_type,
-									 size_t*  consumed_bytes );
+									 size_t*  consumed_bytes, dl_allocator *allocator = 0x0 );
 
 /*
 	Function: dl_util_load_from_file_inplace
@@ -96,12 +100,13 @@ dl_error_t dl_util_load_from_stream( dl_ctx_t dl_ctx,       dl_typeid_t         
 		be used accordingly.
 
 	Parameters:
-		dl_ctx            - Context to use for operations.
-		type              - Type expected to be found in file.
-		filename          - Path to file to load from.
-		filetype          - Type of file to read, see EDLUtilFileType.
-		out_instance      - Pointer to area to load instance to.
-		out_instance_size - Size of buffer pointed to by _ppInstance
+		dl_ctx            	- Context to use for operations.
+		type              	- Type expected to be found in file.
+		filename          	- Path to file to load from.
+		filetype          	- Type of file to read, see EDLUtilFileType.
+		out_instance      	- Pointer to area to load instance to.
+		out_instance_size 	- Size of buffer pointed to by _ppInstance
+		allocator 			- Allocator for doing temp file allocations
 
 	Returns:
 		DL_ERROR_OK on success.
@@ -109,7 +114,7 @@ dl_error_t dl_util_load_from_stream( dl_ctx_t dl_ctx,       dl_typeid_t         
 dl_error_t dl_util_load_from_file_inplace( dl_ctx_t     dl_ctx,       dl_typeid_t         type,
 										   const char*  filename,     dl_util_file_type_t filetype,
 										   void*        out_instance, size_t              out_instance_size,
-										   dl_typeid_t* out_type );
+										   dl_typeid_t* out_type, dl_allocator *allocator = 0x0 );
 
 /*
 	Function: dl_util_store_to_file
@@ -127,6 +132,7 @@ dl_error_t dl_util_load_from_file_inplace( dl_ctx_t     dl_ctx,       dl_typeid_
 		out_endian   - Endian of stored instance if binary.
 		out_ptr_size - Pointer size of stored instance if binary.
 		out_instance - Pointer to instance to write
+		allocator 	 - Allocator for doing temp file allocations
 
 	Returns:
 		DL_ERROR_OK on success.
@@ -134,7 +140,7 @@ dl_error_t dl_util_load_from_file_inplace( dl_ctx_t     dl_ctx,       dl_typeid_
 dl_error_t dl_util_store_to_file( dl_ctx_t    dl_ctx,     dl_typeid_t         type,
 								  const char* filename,   dl_util_file_type_t filetype,
 								  dl_endian_t out_endian, size_t              out_ptr_size,
-								  const void* out_instance );
+								  const void* out_instance, dl_allocator *allocator = 0x0 );
 
 /*
 	Function: dl_util_store_to_stream
@@ -152,6 +158,7 @@ dl_error_t dl_util_store_to_file( dl_ctx_t    dl_ctx,     dl_typeid_t         ty
 		out_endian   - Endian of stored instance if binary.
 		out_ptr_size - Pointer size of stored instance if binary.
 		out_instance - Pointer to instance to write
+		allocator 	 - Allocator for doing temp file allocations
 
 	Returns:
 		DL_ERROR_OK on success.
@@ -159,7 +166,7 @@ dl_error_t dl_util_store_to_file( dl_ctx_t    dl_ctx,     dl_typeid_t         ty
 dl_error_t dl_util_store_to_stream( dl_ctx_t    dl_ctx,     dl_typeid_t         type,
 									FILE*       stream,     dl_util_file_type_t filetype,
 									dl_endian_t out_endian, size_t              out_ptr_size,
-									const void* out_instance );
+									const void* out_instance, dl_allocator *allocator = 0x0 );
 
 #ifdef __cplusplus
 }

--- a/include/dl/dl_util.h
+++ b/include/dl/dl_util.h
@@ -53,7 +53,8 @@ typedef enum
 		filetype     - Type of file to read, see dl_util_file_type_t.
 		out_instance - Pointer to fill with read instance.
 		out_type     - TypeID of instance found in file, can be set to 0x0.
-		allocator 	 - Allocator for doing temp file allocations
+		allocator 	 - Allocator for doing temp file allocations. 0x0 / nullpointer is also
+					   valid and will default to using malloc (default behavior of dl).
 
 	Returns:
 		DL_ERROR_OK on success.
@@ -61,7 +62,7 @@ typedef enum
 dl_error_t dl_util_load_from_file( dl_ctx_t    dl_ctx,       dl_typeid_t         type,
 								   const char* filename,     dl_util_file_type_t filetype,
 								   void**      out_instance, dl_typeid_t*        out_type,
-								   dl_allocator *allocator = 0x0 );
+								   dl_allocator *allocator );
 
 /*
 	Function: dl_util_load_from_stream
@@ -81,7 +82,8 @@ dl_error_t dl_util_load_from_file( dl_ctx_t    dl_ctx,       dl_typeid_t        
 		out_instance   	- Pointer to fill with read instance.
 		out_type       	- TypeID of instance found in file, can be set to 0x0.
 		consumed_bytes 	- Number of bytes read from stream.
-		allocator 		- Allocator for doing temp file allocations
+		allocator 		- Allocator for doing temp file allocations. 0x0 / nullpointer is also
+					   valid and will default to using malloc (default behavior of dl).
 
 	Returns:
 		DL_ERROR_OK on success.
@@ -89,7 +91,7 @@ dl_error_t dl_util_load_from_file( dl_ctx_t    dl_ctx,       dl_typeid_t        
 dl_error_t dl_util_load_from_stream( dl_ctx_t dl_ctx,       dl_typeid_t         type,
 									 FILE*    stream,       dl_util_file_type_t filetype,
 									 void**   out_instance, dl_typeid_t*        out_type,
-									 size_t*  consumed_bytes, dl_allocator *allocator = 0x0 );
+									 size_t*  consumed_bytes, dl_allocator *allocator );
 
 /*
 	Function: dl_util_load_from_file_inplace
@@ -106,7 +108,8 @@ dl_error_t dl_util_load_from_stream( dl_ctx_t dl_ctx,       dl_typeid_t         
 		filetype          	- Type of file to read, see EDLUtilFileType.
 		out_instance      	- Pointer to area to load instance to.
 		out_instance_size 	- Size of buffer pointed to by _ppInstance
-		allocator 			- Allocator for doing temp file allocations
+		allocator 			- Allocator for doing temp file allocations. 0x0 / nullpointer is also
+					   valid and will default to using malloc (default behavior of dl).
 
 	Returns:
 		DL_ERROR_OK on success.
@@ -114,7 +117,7 @@ dl_error_t dl_util_load_from_stream( dl_ctx_t dl_ctx,       dl_typeid_t         
 dl_error_t dl_util_load_from_file_inplace( dl_ctx_t     dl_ctx,       dl_typeid_t         type,
 										   const char*  filename,     dl_util_file_type_t filetype,
 										   void*        out_instance, size_t              out_instance_size,
-										   dl_typeid_t* out_type, dl_allocator *allocator = 0x0 );
+										   dl_typeid_t* out_type, dl_allocator *allocator );
 
 /*
 	Function: dl_util_store_to_file
@@ -132,7 +135,8 @@ dl_error_t dl_util_load_from_file_inplace( dl_ctx_t     dl_ctx,       dl_typeid_
 		out_endian   - Endian of stored instance if binary.
 		out_ptr_size - Pointer size of stored instance if binary.
 		out_instance - Pointer to instance to write
-		allocator 	 - Allocator for doing temp file allocations
+		allocator 	 - Allocator for doing temp file allocations. 0x0 / nullpointer is also
+					   valid and will default to using malloc (default behavior of dl).
 
 	Returns:
 		DL_ERROR_OK on success.
@@ -140,7 +144,7 @@ dl_error_t dl_util_load_from_file_inplace( dl_ctx_t     dl_ctx,       dl_typeid_
 dl_error_t dl_util_store_to_file( dl_ctx_t    dl_ctx,     dl_typeid_t         type,
 								  const char* filename,   dl_util_file_type_t filetype,
 								  dl_endian_t out_endian, size_t              out_ptr_size,
-								  const void* out_instance, dl_allocator *allocator = 0x0 );
+								  const void* out_instance, dl_allocator *allocator );
 
 /*
 	Function: dl_util_store_to_stream
@@ -158,7 +162,8 @@ dl_error_t dl_util_store_to_file( dl_ctx_t    dl_ctx,     dl_typeid_t         ty
 		out_endian   - Endian of stored instance if binary.
 		out_ptr_size - Pointer size of stored instance if binary.
 		out_instance - Pointer to instance to write
-		allocator 	 - Allocator for doing temp file allocations
+		allocator 	 - Allocator for doing temp file allocations. 0x0 / nullpointer is also
+					   valid and will default to using malloc (default behavior of dl).
 
 	Returns:
 		DL_ERROR_OK on success.
@@ -166,7 +171,7 @@ dl_error_t dl_util_store_to_file( dl_ctx_t    dl_ctx,     dl_typeid_t         ty
 dl_error_t dl_util_store_to_stream( dl_ctx_t    dl_ctx,     dl_typeid_t         type,
 									FILE*       stream,     dl_util_file_type_t filetype,
 									dl_endian_t out_endian, size_t              out_ptr_size,
-									const void* out_instance, dl_allocator *allocator = 0x0 );
+									const void* out_instance, dl_allocator *allocator );
 
 #ifdef __cplusplus
 }

--- a/src/dl_alloc.cpp
+++ b/src/dl_alloc.cpp
@@ -17,7 +17,7 @@ static void dl_internal_free( void* ptr, void* /*ctx*/ )
 	free( ptr );
 }
 
-bool dl_allocator_initialize( dl_allocator* alloc, dl_alloc_func alloc_f, dl_realloc_func realloc_f, dl_free_func free_f, void* alloc_ctx )
+int dl_allocator_initialize( dl_allocator* alloc, dl_alloc_func alloc_f, dl_realloc_func realloc_f, dl_free_func free_f, void* alloc_ctx )
 {
 	if( alloc_f == 0x0 && free_f == 0x0 && realloc_f == 0x0 )
 	{
@@ -26,13 +26,13 @@ bool dl_allocator_initialize( dl_allocator* alloc, dl_alloc_func alloc_f, dl_rea
 		alloc->realloc = dl_internal_realloc;
 		alloc->free    = dl_internal_free;
 		alloc->ctx     = 0x0;
-		return true;
+		return 1;
 	}
 
 	if( alloc_f == 0x0 || free_f == 0x0 )
 	{
 		// invalid setup!
-		return false;
+		return 0;
 	}
 
 	alloc->alloc   = alloc_f;
@@ -40,5 +40,5 @@ bool dl_allocator_initialize( dl_allocator* alloc, dl_alloc_func alloc_f, dl_rea
 	alloc->realloc = realloc_f;
 	alloc->ctx     = alloc_ctx;
 
-	return true;
+	return 1;
 }

--- a/src/dl_alloc.h
+++ b/src/dl_alloc.h
@@ -8,21 +8,22 @@
 extern "C" {
 #endif  // __cplusplus
 
-struct dl_allocator
+typedef struct dl_allocator
 {
 	dl_alloc_func   alloc;
 	dl_realloc_func realloc;
 	dl_free_func    free;
 	void* ctx;
-};
+} dl_allocator;
 
 /**
  * Initialize a dl_allocator to be used internally in DL.
  *
  * If alloc_f and free_f is both NULL, malloc, realloc and free will be used.
  * If alloc_f and free_f is not NULL, but realloc_f if NULL a fallback using alloc_f and free_f together with memcpy will be used.
+ * Returns 0 if initialization fails, 1 if it succeeds.
  */
-bool dl_allocator_initialize( dl_allocator* alloc, dl_alloc_func alloc_f, dl_realloc_func realloc_f, dl_free_func free_f, void* alloc_ctx );
+int dl_allocator_initialize( dl_allocator* alloc, dl_alloc_func alloc_f, dl_realloc_func realloc_f, dl_free_func free_f, void* alloc_ctx );
 
 /**
  * Allocator memory on an allocator.

--- a/src/dl_alloc.h
+++ b/src/dl_alloc.h
@@ -4,6 +4,10 @@
 #include <dl/dl.h>
 #include <string.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
 struct dl_allocator
 {
 	dl_alloc_func   alloc;
@@ -52,6 +56,11 @@ inline void* dl_realloc( dl_allocator* alloc, void* ptr, size_t size, size_t old
 	}
 	return new_ptr;
 }
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
 
 #endif // DL_ALLOC_H_INCLUDED
 

--- a/src/dl_util.cpp
+++ b/src/dl_util.cpp
@@ -51,7 +51,7 @@ dl_error_t dl_util_load_from_stream( dl_ctx_t dl_ctx,       	dl_typeid_t        
 									 size_t*  consumed_bytes, 	dl_allocator *allocator /* = 0x0 */ )
 {
 	dl_allocator mallocator;
-	if(allocator == nullptr) {
+	if(allocator == 0x0) {
 		dl_allocator_initialize(&mallocator, 0x0, 0x0, 0x0, 0x0);
 		allocator = &mallocator;
 	}
@@ -181,7 +181,7 @@ dl_error_t dl_util_store_to_stream( dl_ctx_t    dl_ctx,     dl_typeid_t         
 									const void* instance, dl_allocator *allocator /* = 0x0 */ )
 {
 	dl_allocator mallocator;
-	if(allocator == nullptr) {
+	if(allocator == 0x0) {
 		dl_allocator_initialize(&mallocator, 0x0, 0x0, 0x0, 0x0);
 		allocator = &mallocator;
 	}

--- a/src/dl_util.cpp
+++ b/src/dl_util.cpp
@@ -8,7 +8,7 @@
 
 #include <stdio.h>
 
-static unsigned char* dl_read_entire_stream( dl_ctx_t dl_ctx, FILE* file, size_t* out_size )
+static unsigned char* dl_read_entire_stream( dl_allocator *allocator, FILE* file, size_t* out_size )
 {
 	const unsigned int CHUNK_SIZE = 1024;
 	size_t         total_size = 0;
@@ -17,7 +17,7 @@ static unsigned char* dl_read_entire_stream( dl_ctx_t dl_ctx, FILE* file, size_t
 
 	do
 	{
-		out_buffer = (unsigned char*)dl_realloc( &dl_ctx->alloc, out_buffer, CHUNK_SIZE + total_size, total_size );
+		out_buffer = (unsigned char*)dl_realloc( allocator, out_buffer, CHUNK_SIZE + total_size, total_size );
 		chunk_size = fread( out_buffer + total_size, 1, CHUNK_SIZE, file );
 		total_size += chunk_size;
 	}
@@ -27,9 +27,10 @@ static unsigned char* dl_read_entire_stream( dl_ctx_t dl_ctx, FILE* file, size_t
 	return out_buffer;
 }
 
-dl_error_t dl_util_load_from_file( dl_ctx_t    dl_ctx,       dl_typeid_t         type,
-                                   const char* filename,     dl_util_file_type_t filetype,
-                                   void**      out_instance, dl_typeid_t*        out_type )
+dl_error_t dl_util_load_from_file( dl_ctx_t dl_ctx,     		dl_typeid_t         type,
+                                   const char* filename,     	dl_util_file_type_t filetype,
+                                   void**      out_instance, 	dl_typeid_t*        out_type,
+                                   dl_allocator * allocator /* = 0x0 */ )
 {
 	dl_error_t error = DL_ERROR_UTIL_FILE_NOT_FOUND;
 
@@ -37,24 +38,29 @@ dl_error_t dl_util_load_from_file( dl_ctx_t    dl_ctx,       dl_typeid_t        
 
 	if( in_file != 0x0 )
 	{
-		error = dl_util_load_from_stream( dl_ctx, type, in_file, filetype, out_instance, out_type, 0x0 );
+		error = dl_util_load_from_stream( dl_ctx, type, in_file, filetype, out_instance, out_type, 0x0, allocator );
 		fclose(in_file);
 	}
 
 	return error;
 }
 
-dl_error_t dl_util_load_from_stream( dl_ctx_t dl_ctx,       dl_typeid_t         type,
-									 FILE*    stream,       dl_util_file_type_t filetype,
-									 void**   out_instance, dl_typeid_t*        out_type,
-									 size_t*  consumed_bytes )
+dl_error_t dl_util_load_from_stream( dl_ctx_t dl_ctx,       	dl_typeid_t         type,
+									 FILE*    stream,       	dl_util_file_type_t filetype,
+									 void**   out_instance, 	dl_typeid_t*        out_type,
+									 size_t*  consumed_bytes, 	dl_allocator *allocator /* = 0x0 */ )
 {
-	// TODO: this function need to handle alignment for _ppInstance
-	// TODO: this function should take an allocator for the user to be able to control allocations.
-	(void)consumed_bytes; // TODO: Return good stuff here!
+	dl_allocator mallocator;
+	if(allocator == nullptr) {
+		dl_allocator_initialize(&mallocator, 0x0, 0x0, 0x0, 0x0);
+		allocator = &mallocator;
+	}
 
+
+	// TODO: this function need to handle alignment for _ppInstance
+	(void)consumed_bytes; // TODO: Return good stuff here!
 	size_t file_size;
-	unsigned char* file_content = dl_read_entire_stream( dl_ctx, stream, &file_size );
+	unsigned char* file_content = dl_read_entire_stream( allocator, stream, &file_size );
 
 	file_content[file_size] = '\0';
 
@@ -67,7 +73,7 @@ dl_error_t dl_util_load_from_stream( dl_ctx_t dl_ctx,       dl_typeid_t         
 
 	if( ( in_file_type & filetype ) == 0 )
 	{
-		dl_free( &dl_ctx->alloc, file_content );
+		dl_free( allocator, file_content );
 		return DL_ERROR_UTIL_FILE_TYPE_MISMATCH;
 	}
 
@@ -83,16 +89,16 @@ dl_error_t dl_util_load_from_stream( dl_ctx_t dl_ctx,       dl_typeid_t         
 
 			error = dl_convert( dl_ctx, type, file_content, file_size, 0x0, 0, DL_ENDIAN_HOST, sizeof(void*), &load_size );
 
-			if( error != DL_ERROR_OK ) { dl_free( &dl_ctx->alloc, file_content ); return error; }
+			if( error != DL_ERROR_OK ) { dl_free( allocator, file_content ); return error; }
 
 			// convert if needed
 			if( load_size > file_size || info.ptrsize < sizeof(void*) )
 			{
-				load_instance = (unsigned char*)dl_alloc( &dl_ctx->alloc, load_size );
+				load_instance = (unsigned char*)dl_alloc( allocator, load_size );
 
 				error = dl_convert( dl_ctx, type, file_content, file_size, load_instance, load_size, DL_ENDIAN_HOST, sizeof(void*), 0x0 );
 
-				dl_free( &dl_ctx->alloc, file_content );
+				dl_free( allocator, file_content );
 			}
 			else
 			{
@@ -101,7 +107,7 @@ dl_error_t dl_util_load_from_stream( dl_ctx_t dl_ctx,       dl_typeid_t         
 				error = dl_convert_inplace( dl_ctx, type, load_instance, load_size, DL_ENDIAN_HOST, sizeof(void*), 0x0 );
 			}
 
-			if( error != DL_ERROR_OK ) { dl_free( &dl_ctx->alloc, load_instance ); return error; }
+			if( error != DL_ERROR_OK ) { dl_free( allocator, load_instance ); return error; }
 		}
 		break;
 		case DL_UTIL_FILE_TYPE_TEXT:
@@ -110,17 +116,17 @@ dl_error_t dl_util_load_from_stream( dl_ctx_t dl_ctx,       dl_typeid_t         
 			size_t packed_size = 0;
 			error = dl_txt_pack( dl_ctx, (char*)file_content, 0x0, 0, &packed_size );
 
-			if(error != DL_ERROR_OK) { dl_free( &dl_ctx->alloc,file_content); return error; }
+			if(error != DL_ERROR_OK) { dl_free( allocator, file_content); return error; }
 
-			load_instance = (unsigned char*)dl_alloc( &dl_ctx->alloc, packed_size );
+			load_instance = (unsigned char*)dl_alloc( allocator, packed_size );
 
 			error = dl_txt_pack(dl_ctx, (char*)file_content, load_instance, packed_size, 0x0);
 
 			load_size = packed_size;
 
-			dl_free( &dl_ctx->alloc, file_content);
+			dl_free( allocator, file_content);
 
-			if(error != DL_ERROR_OK) { dl_free( &dl_ctx->alloc, load_instance); return error; }
+			if(error != DL_ERROR_OK) { dl_free( allocator, load_instance); return error; }
 
 			if( type == 0 ) // autodetect type
 			{
@@ -154,7 +160,7 @@ dl_error_t dl_util_load_from_file_inplace( dl_ctx_t    dl_ctx,       dl_typeid_t
 dl_error_t dl_util_store_to_file( dl_ctx_t    dl_ctx,     dl_typeid_t         type,
                                   const char* filename,   dl_util_file_type_t filetype,
                                   dl_endian_t out_endian, size_t              out_ptr_size,
-                                  const void* instance )
+                                  const void* instance, dl_allocator *allocator /*= 0x0*/ )
 {
 	FILE* out_file = fopen( filename, filetype == DL_UTIL_FILE_TYPE_BINARY ? "wb" : "w" );
 
@@ -162,7 +168,7 @@ dl_error_t dl_util_store_to_file( dl_ctx_t    dl_ctx,     dl_typeid_t         ty
 
 	if( out_file != 0x0 )
 	{
-		error = dl_util_store_to_stream( dl_ctx, type, out_file, filetype, out_endian, out_ptr_size, instance );
+		error = dl_util_store_to_stream( dl_ctx, type, out_file, filetype, out_endian, out_ptr_size, instance, allocator );
 		fclose( out_file );
 	}
 
@@ -172,8 +178,14 @@ dl_error_t dl_util_store_to_file( dl_ctx_t    dl_ctx,     dl_typeid_t         ty
 dl_error_t dl_util_store_to_stream( dl_ctx_t    dl_ctx,     dl_typeid_t         type,
 									FILE*       stream,     dl_util_file_type_t filetype,
 									dl_endian_t out_endian, size_t              out_ptr_size,
-									const void* instance )
+									const void* instance, dl_allocator *allocator /* = 0x0 */ )
 {
+	dl_allocator mallocator;
+	if(allocator == nullptr) {
+		dl_allocator_initialize(&mallocator, 0x0, 0x0, 0x0, 0x0);
+		allocator = &mallocator;
+	}
+
 	if( filetype == DL_UTIL_FILE_TYPE_AUTO )
 		return DL_ERROR_INVALID_PARAMETER;
 
@@ -186,12 +198,12 @@ dl_error_t dl_util_store_to_stream( dl_ctx_t    dl_ctx,     dl_typeid_t         
 		return error;
 
 	// alloc memory
-	unsigned char* packed_instance = (unsigned char*)dl_alloc( &dl_ctx->alloc, packed_size );
+	unsigned char* packed_instance = (unsigned char*)dl_alloc( allocator, packed_size );
 
 	// pack data
 	error = dl_instance_store( dl_ctx, type, instance, packed_instance, packed_size, 0x0 );
 
-	if( error != DL_ERROR_OK ) { dl_free( &dl_ctx->alloc, packed_instance ); return error; }
+	if( error != DL_ERROR_OK ) { dl_free( allocator, packed_instance ); return error; }
 
 	size_t         out_size = 0;
 	unsigned char* out_data = 0x0;
@@ -203,27 +215,27 @@ dl_error_t dl_util_store_to_stream( dl_ctx_t    dl_ctx,     dl_typeid_t         
 			// calc convert size
 			error = dl_convert( dl_ctx, type, packed_instance, packed_size, 0x0, 0, out_endian, out_ptr_size, &out_size );
 
-			if( error != DL_ERROR_OK ) { dl_free( &dl_ctx->alloc, packed_instance ); return error; }
+			if( error != DL_ERROR_OK ) { dl_free( allocator, packed_instance ); return error; }
 
 			// convert
 			if( out_size > packed_size || out_ptr_size > sizeof(void*) )
 			{
 				// new alloc
-				out_data = (unsigned char*)dl_alloc( &dl_ctx->alloc, out_size );
+				out_data = (unsigned char*)dl_alloc( allocator, out_size );
 
 				// convert
 				error = dl_convert( dl_ctx, type, packed_instance, packed_size, out_data, out_size, out_endian, out_ptr_size, 0x0 );
 
-				dl_free( &dl_ctx->alloc, packed_instance );
+				dl_free( allocator, packed_instance );
 
-				if( error != DL_ERROR_OK ) { dl_free( &dl_ctx->alloc, out_data ); return error; }
+				if( error != DL_ERROR_OK ) { dl_free( allocator, out_data ); return error; }
 			}
 			else
 			{
 				out_data = packed_instance;
 				error = dl_convert_inplace( dl_ctx, type, packed_instance, packed_size, out_endian, out_ptr_size, 0x0 );
 
-				if( error != DL_ERROR_OK ) { dl_free( &dl_ctx->alloc, out_data ); return error; }
+				if( error != DL_ERROR_OK ) { dl_free( allocator, out_data ); return error; }
 			}
 		}
 		break;
@@ -232,17 +244,17 @@ dl_error_t dl_util_store_to_stream( dl_ctx_t    dl_ctx,     dl_typeid_t         
 			// calculate pack-size
 			error = dl_txt_unpack( dl_ctx, type, packed_instance, packed_size, 0x0, 0, &out_size );
 
-			if( error != DL_ERROR_OK ) { dl_free( &dl_ctx->alloc, packed_instance ); return error; }
+			if( error != DL_ERROR_OK ) { dl_free( allocator, packed_instance ); return error; }
 
 			// alloc data
-			out_data = (unsigned char*)dl_alloc( &dl_ctx->alloc, out_size );
+			out_data = (unsigned char*)dl_alloc( allocator, out_size );
 
 			// pack data
 			error = dl_txt_unpack( dl_ctx, type, packed_instance, packed_size, (char*)out_data, out_size, 0x0 );
 
-			dl_free( &dl_ctx->alloc, packed_instance );
+			dl_free( allocator, packed_instance );
 
-			if( error != DL_ERROR_OK ) { dl_free( &dl_ctx->alloc, out_data ); return error; }
+			if( error != DL_ERROR_OK ) { dl_free( allocator, out_data ); return error; }
 		}
 		break;
 		default:
@@ -250,7 +262,7 @@ dl_error_t dl_util_store_to_stream( dl_ctx_t    dl_ctx,     dl_typeid_t         
 	}
 
 	fwrite( out_data, out_size, 1, stream );
-	dl_free( &dl_ctx->alloc,  out_data );
+	dl_free( allocator,  out_data );
 
 	return error;
 }

--- a/src/dl_util.cpp
+++ b/src/dl_util.cpp
@@ -30,7 +30,7 @@ static unsigned char* dl_read_entire_stream( dl_allocator *allocator, FILE* file
 dl_error_t dl_util_load_from_file( dl_ctx_t dl_ctx,     		dl_typeid_t         type,
                                    const char* filename,     	dl_util_file_type_t filetype,
                                    void**      out_instance, 	dl_typeid_t*        out_type,
-                                   dl_allocator * allocator /* = 0x0 */ )
+                                   dl_allocator * allocator )
 {
 	dl_error_t error = DL_ERROR_UTIL_FILE_NOT_FOUND;
 
@@ -48,7 +48,7 @@ dl_error_t dl_util_load_from_file( dl_ctx_t dl_ctx,     		dl_typeid_t         ty
 dl_error_t dl_util_load_from_stream( dl_ctx_t dl_ctx,       	dl_typeid_t         type,
 									 FILE*    stream,       	dl_util_file_type_t filetype,
 									 void**   out_instance, 	dl_typeid_t*        out_type,
-									 size_t*  consumed_bytes, 	dl_allocator *allocator /* = 0x0 */ )
+									 size_t*  consumed_bytes, 	dl_allocator *allocator )
 {
 	dl_allocator mallocator;
 	if(allocator == 0x0) {
@@ -178,7 +178,7 @@ dl_error_t dl_util_store_to_file( dl_ctx_t    dl_ctx,     dl_typeid_t         ty
 dl_error_t dl_util_store_to_stream( dl_ctx_t    dl_ctx,     dl_typeid_t         type,
 									FILE*       stream,     dl_util_file_type_t filetype,
 									dl_endian_t out_endian, size_t              out_ptr_size,
-									const void* instance, dl_allocator *allocator /* = 0x0 */ )
+									const void* instance, dl_allocator *allocator )
 {
 	dl_allocator mallocator;
 	if(allocator == 0x0) {

--- a/tests/dl_test_valid_c.c
+++ b/tests/dl_test_valid_c.c
@@ -3,7 +3,7 @@
 #include "generated/unittest2.h"
 #include "generated/sized_enums.h"
 
-#include "dl_alloc.h"
+#include "../src/dl_alloc.h"
 #include <dl/dl.h>
 #include <dl/dl_convert.h>
 #include <dl/dl_reflect.h>

--- a/tests/dl_test_valid_c.c
+++ b/tests/dl_test_valid_c.c
@@ -3,6 +3,7 @@
 #include "generated/unittest2.h"
 #include "generated/sized_enums.h"
 
+#include "dl_alloc.h"
 #include <dl/dl.h>
 #include <dl/dl_convert.h>
 #include <dl/dl_reflect.h>

--- a/tests/dl_tests_util.cpp
+++ b/tests/dl_tests_util.cpp
@@ -54,19 +54,21 @@ TEST_F( DLUtil, store_load_binary )
 											 DL_UTIL_FILE_TYPE_BINARY,
 											 DL_ENDIAN_HOST,
 											 sizeof(void*),
-											 &p ) );
+											 &p,
+											 0x0 ) );
 
 	union { Pods* p2; void* vp; } conv;
 	conv.p2 = 0x0;
 	dl_typeid_t stored_type;
-																				
+
 	// read struct from temp-flle.
 	EXPECT_DL_ERR_OK( dl_util_load_from_file( Ctx,
 											  Pods::TYPE_ID,
 											  TEMP_FILE_NAME,
 											  DL_UTIL_FILE_TYPE_BINARY,
 											  &conv.vp,
-											  &stored_type ) );
+											  &stored_type,
+											  0x0 ) );
 
 	dl_typeid_t expect = Pods::TYPE_ID;
 	EXPECT_EQ( expect, stored_type );
@@ -83,7 +85,8 @@ TEST_F( DLUtil, store_load_text )
 											 DL_UTIL_FILE_TYPE_TEXT,
 											 DL_ENDIAN_HOST,
 											 sizeof(void*),
-											 &p ) );
+											 &p,
+											 0x0 ) );
 
 	union { Pods* p2; void* vp; } conv;
 	conv.p2 = 0x0;
@@ -95,7 +98,8 @@ TEST_F( DLUtil, store_load_text )
 											  TEMP_FILE_NAME,
 											  DL_UTIL_FILE_TYPE_TEXT,
 											  &conv.vp,
-											  &stored_type ) );
+											  &stored_type,
+											  0x0 ) );
 
 	dl_typeid_t expect = Pods::TYPE_ID;
 	EXPECT_EQ( expect, stored_type );
@@ -111,7 +115,8 @@ TEST_F( DLUtil, load_text_from_binary_error )
 											 DL_UTIL_FILE_TYPE_BINARY,
 											 DL_ENDIAN_HOST,
 											 sizeof(void*),
-											 &p ) );
+											 &p,
+											 0x0 ) );
 
 	union { Pods* p2; void* vp; } conv;
 	conv.p2 = 0x0;
@@ -122,7 +127,8 @@ TEST_F( DLUtil, load_text_from_binary_error )
 																				TEMP_FILE_NAME,
 																				DL_UTIL_FILE_TYPE_TEXT,
 																				&conv.vp,
-																				&stored_type ) );
+																				&stored_type,
+																				0x0 ) );
 
 	EXPECT_EQ( 0x0, conv.p2 ); // should be untouched
 }
@@ -135,7 +141,8 @@ TEST_F( DLUtil, load_binary_from_text_error )
 											 DL_UTIL_FILE_TYPE_TEXT,
 											 DL_ENDIAN_HOST,
 											 sizeof(void*),
-											 &p ) );
+											 &p,
+											 0x0 ) );
 
 	union { Pods* p2; void* vp; } conv;
 	conv.p2 = 0x0;
@@ -146,7 +153,8 @@ TEST_F( DLUtil, load_binary_from_text_error )
 																				TEMP_FILE_NAME,
 																				DL_UTIL_FILE_TYPE_BINARY,
 																				&conv.vp,
-																				&stored_type ) );
+																				&stored_type,
+																				0x0 ) );
 
 	EXPECT_EQ( 0x0, conv.p2 ); // should be untouched
 }
@@ -159,7 +167,8 @@ TEST_F( DLUtil, auto_detect_binary_file_format )
 											 DL_UTIL_FILE_TYPE_BINARY,
 											 DL_ENDIAN_HOST,
 											 sizeof(void*),
-											 &p ) );
+											 &p,
+											 0x0 ) );
 
 	union { Pods* p2; void* vp; } conv;
 	conv.p2 = 0x0;
@@ -170,7 +179,8 @@ TEST_F( DLUtil, auto_detect_binary_file_format )
 											  TEMP_FILE_NAME,
 											  DL_UTIL_FILE_TYPE_AUTO,
 											  &conv.vp,
-											  &stored_type ) );
+											  &stored_type,
+											  0x0 ) );
 
 	dl_typeid_t expect = Pods::TYPE_ID;
 	EXPECT_EQ( expect, stored_type );
@@ -187,7 +197,8 @@ TEST_F( DLUtil, auto_detect_text_file_format )
 											 DL_UTIL_FILE_TYPE_TEXT,
 											 DL_ENDIAN_HOST,
 											 sizeof(void*),
-											 &p ) );
+											 &p,
+											 0x0 ) );
 
 	union { Pods* p2; void* vp; } conv;
 	conv.p2 = 0x0;
@@ -198,7 +209,8 @@ TEST_F( DLUtil, auto_detect_text_file_format )
 											  TEMP_FILE_NAME,
 											  DL_UTIL_FILE_TYPE_AUTO,
 											  &conv.vp,
-											  &stored_type ) );
+											  &stored_type,
+											  0x0 ) );
 
 	dl_typeid_t expect = Pods::TYPE_ID;
 	EXPECT_EQ( expect, stored_type );
@@ -210,7 +222,7 @@ TEST_F( DLUtil, auto_detect_text_file_format )
 TEST_F( DLUtil, dl_util_load_non_existing_file )
 {
 	EXPECT_DL_ERR_EQ( DL_ERROR_UTIL_FILE_NOT_FOUND,
-					  dl_util_load_from_file( Ctx, 0, "whobb whobb whoob", DL_UTIL_FILE_TYPE_AUTO, 0, 0 ) );
+					  dl_util_load_from_file( Ctx, 0, "whobb whobb whoob", DL_UTIL_FILE_TYPE_AUTO, 0, 0, 0 ) );
 }
 
 // store in other endian and load!

--- a/tool/dl_pack/dl_pack.cpp
+++ b/tool/dl_pack/dl_pack.cpp
@@ -171,7 +171,7 @@ int main( int argc, const char** argv )
 			case 'e':
 				if(strcmp(go_ctx.current_opt_arg, "little") == 0)
 					out_endian = DL_ENDIAN_LITTLE;
-				else if(strcmp(go_ctx.current_opt_arg, "big") == 0) 
+				else if(strcmp(go_ctx.current_opt_arg, "big") == 0)
 					out_endian = DL_ENDIAN_BIG;
 				else
 					M_ERROR_AND_QUIT("endian-flag need \"little\" or \"big\", not \"%s\"!", go_ctx.current_opt_arg);
@@ -226,7 +226,7 @@ int main( int argc, const char** argv )
 		dl_typeid_t type;
 		void* instance = 0;
 
-		dl_error_t err = dl_util_load_from_stream( dl_ctx, 0, in_file, DL_UTIL_FILE_TYPE_AUTO, &instance, &type, 0x0 );
+		dl_error_t err = dl_util_load_from_stream( dl_ctx, 0, in_file, DL_UTIL_FILE_TYPE_AUTO, &instance, &type, 0x0, 0x0 );
 		if( err != DL_ERROR_OK )
 			M_ERROR_AND_QUIT( "DL error reading stream: %s", dl_error_to_string( err ) );
 
@@ -236,7 +236,8 @@ int main( int argc, const char** argv )
 									   do_unpack == 1 ? DL_UTIL_FILE_TYPE_TEXT : DL_UTIL_FILE_TYPE_BINARY,
 									   out_endian,
 									   out_ptr_size,
-									   instance );
+									   instance,
+									   0x0 );
 
 		if( err != DL_ERROR_OK )
 			M_ERROR_AND_QUIT( "DL error writing stream: %s", dl_error_to_string( err ) );


### PR DESCRIPTION
The dl_util functions were changed to use the internal allocator. The should not be using the internal allocator since that one is dedicated to be used to the type library. Unfortunately there are conditions as to when the allocations are actually done, so we can't use one temp for the file allocations and one for the instance allocations, since they are sometimes the same. This is to solve issue #90.