### PR TITLE
Fix for bad offset for unions to union types.

### DIFF
--- a/src/dl.cpp
+++ b/src/dl.cpp
@@ -360,7 +360,8 @@ static dl_error_t dl_internal_instance_store( dl_ctx_t dl_ctx, const dl_type_des
 	if( type->flags & DL_TYPE_FLAG_IS_UNION )
 	{
 		// TODO: extract to helper-function?
-		size_t max_member_size = dl_internal_largest_member_size( dl_ctx, type, DL_PTR_SIZE_HOST );
+		size_t max_member_alignment = dl_internal_largest_member_alignment( dl_ctx, type, DL_PTR_SIZE_HOST );
+		size_t max_member_size = dl_internal_align_up(dl_internal_largest_member_size( dl_ctx, type, DL_PTR_SIZE_HOST ), max_member_alignment);
 
 		// find member index from union type ...
 		uint32_t union_type = *((uint32_t*)(instance + max_member_size));

--- a/src/dl_patch_ptr.cpp
+++ b/src/dl_patch_ptr.cpp
@@ -226,7 +226,8 @@ void dl_internal_patch_struct( dl_ctx_t            ctx,
 		if( type->flags & DL_TYPE_FLAG_IS_UNION )
 		{
 			// TODO: extract to helper-function?
-			size_t max_member_size = dl_internal_largest_member_size( ctx, type, DL_PTR_SIZE_HOST );
+			size_t max_member_alignment = dl_internal_largest_member_alignment( ctx, type, DL_PTR_SIZE_HOST );
+			size_t max_member_size = dl_internal_align_up(dl_internal_largest_member_size( ctx, type, DL_PTR_SIZE_HOST ), max_member_alignment);
 
 			// find member index from union type ...
 			uint32_t union_type = *((uint32_t*)(struct_data + max_member_size));
@@ -266,7 +267,8 @@ void dl_internal_patch_instance( dl_ctx_t            ctx,
 	if( type->flags & DL_TYPE_FLAG_IS_UNION )
 	{
 		// TODO: extract to helper-function?
-		size_t max_member_size = dl_internal_largest_member_size( ctx, type, DL_PTR_SIZE_HOST );
+		size_t max_member_alignment = dl_internal_largest_member_alignment( ctx, type, DL_PTR_SIZE_HOST );
+		size_t max_member_size = dl_internal_align_up(dl_internal_largest_member_size( ctx, type, DL_PTR_SIZE_HOST ), max_member_alignment);
 
 		// find member index from union type ...
 		uint32_t union_type = *((uint32_t*)(instance + max_member_size));

--- a/src/dl_txt_pack.cpp
+++ b/src/dl_txt_pack.cpp
@@ -870,8 +870,9 @@ static void dl_txt_pack_eat_and_write_struct( dl_ctx_t dl_ctx, dl_txt_pack_ctx* 
 	if( type->flags & DL_TYPE_FLAG_IS_UNION )
 	{
 		size_t max_member_size = dl_internal_largest_member_size( dl_ctx, type, DL_PTR_SIZE_HOST );
+		size_t max_member_alignment = dl_internal_largest_member_alignment( dl_ctx, type, DL_PTR_SIZE_HOST );
 		dl_binary_writer_seek_set( packctx->writer, instance_pos + max_member_size );
-		dl_binary_writer_align( packctx->writer, 4 );
+		dl_binary_writer_align( packctx->writer, max_member_alignment );
 		dl_binary_writer_write_uint32( packctx->writer, member_name_hash );
 	}
 	else

--- a/src/dl_typelib_read_txt.cpp
+++ b/src/dl_typelib_read_txt.cpp
@@ -424,8 +424,8 @@ static void dl_load_txt_calc_type_size_and_align( dl_ctx_t ctx, dl_txt_read_ctx*
 	if( type->flags & DL_TYPE_FLAG_IS_UNION )
 	{
 		// ... add size for the union type flag ...
-		size[DL_PTR_SIZE_32BIT] = dl_internal_align_up( size[DL_PTR_SIZE_32BIT], 4 ) + (uint32_t)sizeof(uint32_t);
-		size[DL_PTR_SIZE_64BIT] = dl_internal_align_up( size[DL_PTR_SIZE_64BIT], 4 ) + (uint32_t)sizeof(uint32_t);
+		size[DL_PTR_SIZE_32BIT] = dl_internal_align_up( size[DL_PTR_SIZE_32BIT], align[DL_PTR_SIZE_32BIT] ) + (uint32_t)sizeof(uint32_t);
+		size[DL_PTR_SIZE_64BIT] = dl_internal_align_up( size[DL_PTR_SIZE_64BIT], align[DL_PTR_SIZE_64BIT] ) + (uint32_t)sizeof(uint32_t);
 	}
 
 	type->size[DL_PTR_SIZE_32BIT] = dl_internal_align_up( size[DL_PTR_SIZE_32BIT], align[DL_PTR_SIZE_32BIT] );

--- a/src/dl_types.h
+++ b/src/dl_types.h
@@ -413,6 +413,17 @@ static inline uint32_t dl_internal_largest_member_size( dl_ctx_t ctx, const dl_t
 	return max_member_size;
 }
 
+static inline uint32_t dl_internal_largest_member_alignment(dl_ctx_t ctx, const dl_type_desc* type, dl_ptr_size_t ptr_size)
+{
+	uint32_t max_member_alignment = 0; // TODO: calc and store this in type?
+	for (uint32_t member_index = 0; member_index < type->member_count; ++member_index)
+	{
+		const dl_member_desc* member = dl_get_type_member(ctx, type, member_index);
+		max_member_alignment = member->alignment[ptr_size] > max_member_alignment ? member->alignment[ptr_size] : max_member_alignment;
+	}
+	return max_member_alignment;
+}
+
 static inline const dl_member_desc* dl_internal_find_member_desc_by_name_hash( dl_ctx_t dl_ctx, const dl_type_desc* type, uint32_t name_hash )
 {
 	for( uint32_t member_index = 0; member_index < type->member_count; ++member_index )

--- a/tests/dl_tests_reflect.cpp
+++ b/tests/dl_tests_reflect.cpp
@@ -285,3 +285,26 @@ TEST_F(DLReflect, type_strings)
 	EXPECT_STREQ( "u64_2", BugTest1_InArray_members[1].name );
 	EXPECT_STREQ( "u16",   BugTest1_InArray_members[2].name );
 }
+
+TEST_F(DLReflect, struct_with_union_sizes)
+{
+	dl_type_info_t union_with_weird_members_event_info;
+	EXPECT_DL_ERR_OK(dl_reflect_get_type_info(Ctx, union_with_weird_members_event_TYPE_ID, &union_with_weird_members_event_info));
+	EXPECT_EQ(union_with_weird_members_event_info.size, sizeof(union_with_weird_members_event));
+}
+
+TEST_F(DLReflect, struct_sizes)
+{
+	dl_type_info_t struct_with_a_bitfield_info;
+	EXPECT_DL_ERR_OK(dl_reflect_get_type_info(Ctx, struct_with_a_bitfield_TYPE_ID, &struct_with_a_bitfield_info));
+	EXPECT_EQ(struct_with_a_bitfield_info.size, sizeof(struct_with_a_bitfield));
+
+	dl_type_info_t struct_with_some_defaults_info;
+	EXPECT_DL_ERR_OK(dl_reflect_get_type_info(Ctx, struct_with_some_defaults_TYPE_ID, &struct_with_some_defaults_info));
+	EXPECT_EQ(struct_with_some_defaults_info.size, sizeof(struct_with_some_defaults));
+
+	dl_type_info_t struct_with_one_member_and_default_info;
+	EXPECT_DL_ERR_OK(dl_reflect_get_type_info(Ctx, struct_with_one_member_and_default_TYPE_ID, &struct_with_one_member_and_default_info));
+	EXPECT_EQ(struct_with_one_member_and_default_info.size, sizeof(struct_with_one_member_and_default));
+
+}

--- a/tests/dl_tests_txt.cpp
+++ b/tests/dl_tests_txt.cpp
@@ -535,32 +535,41 @@ TEST_F( DLText, invalid_data_format )
 	EXPECT_DL_ERR_EQ( DL_ERROR_TXT_PARSE_ERROR, dl_txt_pack( Ctx, STRINGIFY( { "Pods" : true } ), out_data_text, DL_ARRAY_LENGTH(out_data_text), 0x0 ) );
 }
 
-// This fails.
-/*
 TEST_F( DLText, basic_union_type_assignment )
 {
 	const char* text_data = STRINGIFY(
-		{
-			"array_with_struct_of_union" : {
-				"my_list" : [
-					{
-						"my_data" : {
-						},
-						"my_member_1" : 2
+	{
+		"struct_with_array_of_weird_unions" : {
+			"event_array" : [
+				{
+					"delay" : 0,
+					"effect" : {
+						"hide_all_meshes" : {
+						}
 					}
-				]
-			}
+				},
+				{
+					"delay" : 0
+					"effect" : {
+						"spawn_particles" : {
+							"my_variable_1" : 12345678910,
+							"my_variable_3" : 1
+						}
+					}
+				}
+			]
 		}
+	}
 	);
 	char data_buffer[1024];
 
 	unsigned char out_data_text[1024];
 
 	EXPECT_DL_ERR_OK( dl_txt_pack( Ctx, text_data, out_data_text, DL_ARRAY_LENGTH(out_data_text), 0x0) );
-	EXPECT_DL_ERR_OK( dl_instance_load( Ctx, array_with_struct_of_union::TYPE_ID, data_buffer, DL_ARRAY_LENGTH(data_buffer), out_data_text, DL_ARRAY_LENGTH(out_data_text), 0x0 ) );
-	array_with_struct_of_union *t1 = (array_with_struct_of_union*)data_buffer;
-	EXPECT_EQ(test_union_simple_type_item1, t1->my_list[0].my_data.type);
-} */
+	EXPECT_DL_ERR_OK( dl_instance_load( Ctx, struct_with_array_of_weird_unions::TYPE_ID, data_buffer, DL_ARRAY_LENGTH(data_buffer), out_data_text, DL_ARRAY_LENGTH(out_data_text), 0x0 ) );
+	struct_with_array_of_weird_unions *t1 = (struct_with_array_of_weird_unions*)data_buffer;
+	EXPECT_EQ(union_with_weird_members_type_hide_all_meshes, t1->event_array[0].effect.type);
+}
 
 TEST_F( DLText, basic_bool_all_true )
 {

--- a/tests/dl_tests_txt.cpp
+++ b/tests/dl_tests_txt.cpp
@@ -567,7 +567,8 @@ TEST_F( DLText, basic_union_type_assignment )
 
 	EXPECT_DL_ERR_OK( dl_txt_pack( Ctx, text_data, out_data_text, DL_ARRAY_LENGTH(out_data_text), 0x0) );
 	EXPECT_DL_ERR_OK( dl_instance_load( Ctx, struct_with_array_of_weird_unions::TYPE_ID, data_buffer, DL_ARRAY_LENGTH(data_buffer), out_data_text, DL_ARRAY_LENGTH(out_data_text), 0x0 ) );
-	struct_with_array_of_weird_unions *t1 = (struct_with_array_of_weird_unions*)data_buffer;
+	void* temp_ptr = data_buffer;
+	struct_with_array_of_weird_unions *t1 = (struct_with_array_of_weird_unions *)temp_ptr;
 	EXPECT_EQ(union_with_weird_members_type_hide_all_meshes, t1->event_array[0].effect.type);
 }
 

--- a/tests/unittest.tld
+++ b/tests/unittest.tld
@@ -71,13 +71,6 @@
 				{ "name" : "item2", "type" : "fp32"  },
 				{ "name" : "item3", "type" : "Pods"  }
 			]
-		},
-		"test_union_with_default" : {
-			"members" : [
-				{ "name" : "empty", "type" : "default_empty_type" },
-				{ "name" : "item1", "type" : "int32" },
-				{ "name" : "item3", "type" : "Pods"  }
-			]
 		}
 	},
 
@@ -323,21 +316,38 @@
 			]
 		},
 
-		"struct_with_union" : {
+		"struct_with_a_bitfield" : {
+			"comment" : "! not_reloadable",
 			"members" : [
-				{ "name" : "my_data", "type" : "test_union_with_default" },
-				{ "name" : "my_member_1", "type" : "uint32" }
+				{	"name" : "my_variable_1",	"type" : "uint64", "default" : 0 },
+				{	"name" : "my_variable_2",	"type" : "uint32", "default" : 0 },
+				{	"name" : "my_variable_3",	"type" : "bitfield:1" }
 			]
 		},
-
-		"array_with_struct_of_union" : {
+		"struct_with_some_defaults" : {
 			"members" : [
-				{ "name" : "my_list", "type" : "struct_with_union[]" }
+				{ 	"name" : "some_variable_1", 	"type" : "uint32" },
+				{	"name" : "some_variable_2",		"type" : "fp32",			"default" : 0.5 },
+				{ 	"name" : "some_variable_3",		"type" : "fp32",			"default" : 0 },
+				{	"name" : "some_variable_4",		"type" : "fp32",			"default" : 20 },
+				{	"name" : "some_variable_5",		"type" : "fp32",			"default" : 0.1 }
+			]
+		},
+		"struct_with_one_member_and_default" : {
+			"members" : [
+				{	"name" : "dummy", "type" : "uint32", "default" : 0 }
 			]
 		}
 	},
-
 	"unions" : {
+		"union_with_weird_members" : {
+			"members" : [
+				{ "name" : "spawn_particles",	"type" : "struct_with_a_bitfield" },
+				{ "name" : "decay",				"type" : "struct_with_some_defaults" },
+				{ "name" : "hide_all_meshes",	"type" : "struct_with_one_member_and_default" }
+			]
+		},
+
 		"test_union_inline_array" : {
 			"members" : [
 				{ "name" : "i32",    "type" : "int32" },
@@ -367,6 +377,17 @@
 		}
 	},
 	"types" : {
+		"union_with_weird_members_event" : {
+			"members" : [
+				{	"name" : "effect",				"type" : "union_with_weird_members" },
+				{	"name" : "delay",				"type" : "fp32", "default" : 0 }
+			]
+		},
+		"struct_with_array_of_weird_unions" : {
+			"members" : [
+				{ "name" : "event_array",				"type" : "union_with_weird_members_event[]" }
+			]
+		},
 		"test_with_union_array" : {
 			"members" : [
 				{ "name" : "properties", "type" : "test_has_union_array[]" }


### PR DESCRIPTION
Previously, the offset calculated for the type that is set for unions was aligned by 4 bytes. This alignment must be 8 bytes for unions with structs that require 8 byte alignment. This is fixed both in the type library reader and the text packer. Also added a few unit tests to cover this and some more.

This is to solve issue #94.