### PR TITLE
Support for union enums to be indexed

### DIFF
--- a/include/dl/dl_reflect.h
+++ b/include/dl/dl_reflect.h
@@ -38,6 +38,7 @@ typedef struct dl_type_info
 	unsigned int is_extern : 1;
 	unsigned int is_union : 1;
 	unsigned int should_verify : 1;
+	unsigned int hash_union_type : 1;
 } dl_type_info_t;
 
 /*

--- a/src/dl.cpp
+++ b/src/dl.cpp
@@ -363,7 +363,12 @@ static dl_error_t dl_internal_instance_store( dl_ctx_t dl_ctx, const dl_type_des
 
 		// find member index from union type ...
 		uint32_t union_type = *((uint32_t*)(instance + type_offset));
-		const dl_member_desc* member = dl_internal_find_member_desc_by_name_hash( dl_ctx, type, union_type );
+
+		const dl_member_desc* member;
+		if(type->flags & DL_TYPE_FLAG_HASH_UNION_TYPE)
+			member = dl_internal_find_member_desc_by_name_hash( dl_ctx, type, union_type );
+		else
+			member = dl_get_type_member( dl_ctx, type, union_type );
 
 		dl_error_t err = dl_internal_store_member( dl_ctx, member, instance + member->offset[DL_PTR_SIZE_HOST], store_ctx );
 		if( err != DL_ERROR_OK )

--- a/src/dl_convert.cpp
+++ b/src/dl_convert.cpp
@@ -376,7 +376,14 @@ static dl_error_t dl_internal_convert_collect_instances( dl_ctx_t            dl_
 
 		// find member index from union type ...
 		uint32_t union_type = *((uint32_t*)(instance + type_offset));
-		const dl_member_desc* member = dl_internal_find_member_desc_by_name_hash( dl_ctx, type, union_type );
+		const dl_member_desc* member;
+		if(type->flags & DL_TYPE_FLAG_HASH_UNION_TYPE)
+			member = dl_internal_find_member_desc_by_name_hash(dl_ctx, type, union_type);
+		else 
+		{
+			DL_ASSERT(union_type < type->member_count, "Bad union member index.");
+			member = dl_get_type_member(dl_ctx, type, union_type);
+		}
 		const uint8_t* member_data = instance + member->offset[convert_ctx.src_ptr_size];
 
 		return dl_internal_convert_collect_instances_from_member( dl_ctx, member, member_data, base_data, convert_ctx );
@@ -625,7 +632,13 @@ static dl_error_t dl_internal_convert_write_struct( dl_ctx_t            dl_ctx,
 		size_t tgt_type_offset = dl_internal_union_type_offset( dl_ctx, type, conv_ctx.target_ptr_size );
 
 		uint32_t union_type = *((uint32_t*)(instance + src_type_offset));
-		const dl_member_desc* member = dl_internal_find_member_desc_by_name_hash( dl_ctx, type, union_type );
+		const dl_member_desc* member;
+		if((type->flags & DL_TYPE_FLAG_HASH_UNION_TYPE))
+			member = dl_internal_find_member_desc_by_name_hash( dl_ctx, type, union_type );
+		else {
+			DL_ASSERT(union_type < type->member_count, "Bad union member index.");
+			member = dl_get_type_member(dl_ctx, type, union_type);
+		}
 		const uint8_t* member_data = instance + member->offset[conv_ctx.src_ptr_size];
 
 		uint32_t member_index = 0;

--- a/src/dl_patch_ptr.cpp
+++ b/src/dl_patch_ptr.cpp
@@ -226,7 +226,13 @@ static void dl_internal_patch_union( dl_ctx_t            ctx,
 
 	// find member index from union type ...
 	uint32_t union_type = *((uint32_t*)(union_data + type_offset));
-	const dl_member_desc* member = dl_internal_find_member_desc_by_name_hash( ctx, type, union_type );
+
+	const dl_member_desc* member;
+	if(type->flags & DL_TYPE_FLAG_HASH_UNION_TYPE)
+		member = dl_internal_find_member_desc_by_name_hash( ctx, type, union_type );
+	else
+		member = dl_get_type_member( ctx, type, union_type );
+
 	DL_ASSERT(member->offset[DL_PTR_SIZE_HOST] == 0);
 	dl_internal_patch_member( ctx, member, union_data, base_address, patch_distance, patched_ptrs );
 }

--- a/src/dl_reflect.cpp
+++ b/src/dl_reflect.cpp
@@ -42,6 +42,7 @@ static void dl_reflect_copy_type_info( dl_ctx_t ctx, dl_type_info_t* typeinfo, c
 	typeinfo->is_extern     = ( type->flags & DL_TYPE_FLAG_IS_EXTERNAL ) ? 1 : 0;
 	typeinfo->is_union      = ( type->flags & DL_TYPE_FLAG_IS_UNION ) ? 1 : 0;
 	typeinfo->should_verify = ( type->flags & DL_TYPE_FLAG_VERIFY_EXTERNAL_SIZE_ALIGN ) ? 1 : 0;
+	typeinfo->hash_union_type = ( type->flags & DL_TYPE_FLAG_HASH_UNION_TYPE ) ? 1 : 0;
 }
 
 static void dl_reflect_copy_enum_info( dl_ctx_t ctx, dl_enum_info_t* enuminfo, const dl_enum_desc* enum_ )

--- a/src/dl_txt_pack.cpp
+++ b/src/dl_txt_pack.cpp
@@ -525,30 +525,6 @@ static void dl_txt_pack_array_item_size_align( dl_ctx_t dl_ctx,
 	}
 }
 
-const char* dl_txt_skip_array( const char* iter, const char* end )
-{
-	iter = dl_txt_skip_white( iter, end );
-	if( *iter != '[' )
-		return "\0";
-	++iter;
-
-	int depth = 1;
-	while( iter != end && depth > 0 )
-	{
-		iter = dl_txt_skip_white( iter, end );
-		switch(*iter)
-		{
-			case 0x0: return "\0";
-			case '[': ++depth; break;
-			case ']': --depth; break;
-			default: break;
-		}
-		++iter;
-	}
-
-	return iter;
-}
-
 const char* dl_txt_skip_map( const char* iter, const char* end )
 {
 	iter = dl_txt_skip_white( iter, end );
@@ -565,6 +541,30 @@ const char* dl_txt_skip_map( const char* iter, const char* end )
 			case 0x0: return "\0";
 			case '{': ++depth; break;
 			case '}': --depth; break;
+			default: break;
+		}
+		++iter;
+	}
+
+	return iter;
+}
+
+const char* dl_txt_skip_array( const char* iter, const char* end )
+{
+	iter = dl_txt_skip_white( iter, end );
+	if( *iter != '[' )
+		return "\0";
+	++iter;
+
+	int depth = 1;
+	while( iter != end && depth > 0 )
+	{
+		iter = dl_txt_skip_white( iter, end );
+		switch(*iter)
+		{
+			case 0x0: return "\0";
+			case '[': ++depth; break;
+			case ']': --depth; break;
 			default: break;
 		}
 		++iter;
@@ -698,7 +698,7 @@ static uint32_t dl_txt_pack_find_array_length( dl_ctx_t dl_ctx, dl_txt_pack_ctx*
 						return last_was_comma ? array_length - 1 : array_length;
 					default:
 						dl_txt_read_failed( dl_ctx, &packctx->read_ctx, DL_ERROR_TXT_PARSE_ERROR,
-									"Invalid txt-format, are you missing an '}' or an ']'?");
+									"Invalid txt-format, are you missing an '}', received %c", *iter);
 					// TODO: I guess one can fool this parser by adding a ] or , in a comment at "the right place(tm)"
 				}
 			}

--- a/src/dl_txt_pack.cpp
+++ b/src/dl_txt_pack.cpp
@@ -1098,7 +1098,10 @@ static void dl_txt_pack_eat_and_write_struct( dl_ctx_t dl_ctx, dl_txt_pack_ctx* 
 	{
 		size_t type_offset = dl_internal_union_type_offset( dl_ctx, type, DL_PTR_SIZE_HOST );
 		dl_binary_writer_seek_set( packctx->writer, instance_pos + type_offset );
-		dl_binary_writer_write_uint32( packctx->writer, member_name_hash );
+		if( type->flags & DL_TYPE_FLAG_HASH_UNION_TYPE )
+			dl_binary_writer_write_uint32( packctx->writer, member_name_hash );
+		else
+			dl_binary_writer_write_uint32( packctx->writer, dl_internal_find_member( dl_ctx, type, member_name_hash ) );
 	}
 	else
 	{

--- a/src/dl_txt_unpack.cpp
+++ b/src/dl_txt_unpack.cpp
@@ -683,7 +683,15 @@ static void dl_txt_unpack_struct( dl_ctx_t dl_ctx, dl_txt_unpack_ctx* unpack_ctx
 
 		// find member index from union type ...
 		uint32_t union_type = *((uint32_t*)(struct_data + type_offset));
-		const dl_member_desc* member = dl_internal_find_member_desc_by_name_hash( dl_ctx, type, union_type );
+		const dl_member_desc* member;
+		// Can be index instead of typeid.
+		if ((type->flags & DL_TYPE_FLAG_IS_UNION) && !(type->flags & DL_TYPE_FLAG_HASH_UNION_TYPE))
+		{
+			DL_ASSERT(union_type < type->member_count, "Bad union member index.");
+			member = dl_get_type_member(dl_ctx, type, union_type);
+		}
+		else
+			member = dl_internal_find_member_desc_by_name_hash(dl_ctx, type, union_type);
 		dl_txt_unpack_member( dl_ctx, unpack_ctx, writer, member, struct_data + member->offset[DL_PTR_SIZE_HOST] );
 		dl_binary_writer_write( writer, "\n", 1 );
 	}

--- a/src/dl_typelib_read_txt.cpp
+++ b/src/dl_typelib_read_txt.cpp
@@ -1081,8 +1081,6 @@ static void dl_context_load_txt_type_library_read_type( dl_ctx_t ctx, dl_txt_rea
 								 key.len, key.str );
 	} while( dl_txt_try_eat_char( read_state, ',') );
 
-	dl_typeid_t tid = dl_internal_hash_buffer( (const uint8_t*)name->str, (size_t)name->len );
-
 	if( member_count == 0 )
 		dl_txt_read_failed( ctx, read_state, DL_ERROR_TYPELIB_MISSING_MEMBERS_IN_TYPE, "types without members are not allowed" );
 

--- a/src/dl_typelib_read_txt.cpp
+++ b/src/dl_typelib_read_txt.cpp
@@ -1033,9 +1033,11 @@ static void dl_context_load_txt_type_library_read_type( dl_ctx_t ctx, dl_txt_rea
 	uint32_t align = 0;
 	bool is_extern = false;
 	bool verify = true;
+	bool hash_union_type = true;
 	uint32_t member_count = 0;
 	uint32_t member_start = ctx->member_count;
 	dl_txt_read_substr comment = {0,0};
+	dl_typeid_t tid = dl_internal_hash_buffer((const uint8_t*)name->str, (size_t)name->len);
 
 	do
 	{
@@ -1064,6 +1066,14 @@ static void dl_context_load_txt_type_library_read_type( dl_ctx_t ctx, dl_txt_rea
 		else if( strncmp( "comment", key.str, 7 ) == 0 )
 		{
 			comment = dl_txt_eat_and_expect_string( ctx, read_state );
+		}
+		else if( strncmp( "hash_union_type", key.str, 15 ) == 0)
+		{
+			if(!is_union)
+				dl_txt_read_failed( ctx, read_state, DL_ERROR_MALFORMED_DATA,
+								 "unexpected hash_union_type key in a non-unit type data.");
+			else
+				hash_union_type = dl_txt_eat_bool( read_state ) == 1;
 		}
 		else
 			dl_txt_read_failed( ctx, read_state, DL_ERROR_MALFORMED_DATA,
@@ -1094,6 +1104,8 @@ static void dl_context_load_txt_type_library_read_type( dl_ctx_t ctx, dl_txt_rea
 		type->flags |= (uint32_t)DL_TYPE_FLAG_IS_UNION;
 	if( verify )
 		type->flags |= (uint32_t)DL_TYPE_FLAG_VERIFY_EXTERNAL_SIZE_ALIGN;
+	if( hash_union_type )
+		type->flags |= (uint32_t)DL_TYPE_FLAG_HASH_UNION_TYPE;
 
 	dl_txt_eat_char( ctx, read_state, '}' );
 }

--- a/src/dl_typelib_write_c_header.cpp
+++ b/src/dl_typelib_write_c_header.cpp
@@ -700,7 +700,10 @@ static void dl_context_write_c_header_types( dl_binary_writer* writer, dl_ctx_t 
 			// ... generate an enum for union-members ...
 			for( unsigned int member_index = 0; member_index < type->member_count; ++member_index )
 			{
-				dl_binary_writer_write_string_fmt( writer, "    %s_type_%s = 0x%08X", type->name, members[member_index].name, dl_internal_hash_string(members[member_index].name) );
+				if( type->hash_union_type )
+					dl_binary_writer_write_string_fmt( writer, "    %s_type_%s = 0x%08X", type->name, members[member_index].name, dl_internal_hash_string(members[member_index].name) );
+				else
+					dl_binary_writer_write_string_fmt( writer, "    %s_type_%s = %d", type->name, members[member_index].name, member_index );
 
 				if( member_index < type->member_count - 1 )
 					dl_binary_writer_write_string_fmt( writer, ",\n" );

--- a/src/dl_types.h
+++ b/src/dl_types.h
@@ -212,6 +212,7 @@ enum dl_type_flags
 	DL_TYPE_FLAG_IS_EXTERNAL                = 1 << 1, ///< the type is marked as "external", this says that the type is not emitted in headers and expected to get defined by the user.
 	DL_TYPE_FLAG_IS_UNION                   = 1 << 2, ///< the type is a "union" type.
 	DL_TYPE_FLAG_VERIFY_EXTERNAL_SIZE_ALIGN = 1 << 3, ///< the type is a "union" type.
+	DL_TYPE_FLAG_HASH_UNION_TYPE            = 1 << 4, ///< the type forces union types to be hashed or not hashed
 
 	DL_TYPE_FLAG_DEFAULT = 0,
 };
@@ -461,7 +462,9 @@ static inline bool dl_internal_find_enum_value( dl_ctx_t ctx, const dl_enum_desc
 	for( unsigned int j = 0; j < e->alias_count; ++j )
 	{
 		const dl_enum_alias_desc* a = dl_get_enum_alias( ctx, e, j );
-		if( strncmp( dl_internal_enum_alias_name( ctx, a ), name, name_len ) == 0 )
+		const char* alias_name = dl_internal_enum_alias_name(ctx, a);
+		size_t alias_name_len = strlen(alias_name);
+		if( name_len == alias_name_len && strncmp(alias_name, name, name_len ) == 0 )
 		{
 			*value = ctx->enum_value_descs[ a->value_index ].value;
 			return true;

--- a/tests/dl_tests_union.cpp
+++ b/tests/dl_tests_union.cpp
@@ -229,6 +229,21 @@ TYPED_TEST(DLBase, union_in_array)
 	EXPECT_ARRAY_EQ( original.properties[1].value.ints.count,   original.properties[1].value.ints.data,   loaded[0].properties[1].value.ints.data );
 }
 
+TYPED_TEST(DLBase, indexed_union)
+{
+	EXPECT_EQ(indexed_union_type_effect, 0);
+	EXPECT_EQ(indexed_union_type_delay, 1);
+	indexed_union idu;
+	idu.type = indexed_union_type_delay;
+	idu.value.delay = 7.f;
+
+
+	indexed_union loaded[10];
+	this->do_the_round_about( indexed_union::TYPE_ID, &idu, loaded, sizeof(loaded) );
+	EXPECT_EQ(loaded[0].type, indexed_union_type_delay);
+	EXPECT_EQ(loaded[0].value.delay, idu.value.delay);
+}
+
 TYPED_TEST(DLBase, ptr_to_union)
 {
 }

--- a/tests/unittest.tld
+++ b/tests/unittest.tld
@@ -405,6 +405,13 @@
 				{ "name": "floats", "type": "fp32[]"  },
 				{ "name": "ints",   "type": "int32[]" }
 			]
+		},
+		"indexed_union" : {
+			"hash_union_type" : false,
+			"members" : [
+				{	"name" : "effect",				"type" : "union_with_weird_members" },
+				{	"name" : "delay",				"type" : "fp32", "default" : 0 }
+			]
 		}
 	},
 	"types" : {


### PR DESCRIPTION
Support for unions to either hash names or use member-index for union type enum.

This is default as it used to be, so fully back-compatible. You can now add ""hash_union_type" : false, " to your union and it will be 0/1/2 etc mapped for the members rather than the hashed name.