### PR TITLE
No-default-packing and pack-flags

### DIFF
--- a/include/dl/dl_txt.h
+++ b/include/dl/dl_txt.h
@@ -14,6 +14,12 @@
 extern "C" {
 #endif
 
+typedef enum {
+	DL_PACKFLAGS_NONE = 0,
+	DL_PACKFLAGS_NO_DEFAULTS = 1 << 0, 						// Causes the packing to not write the defaults into the packed instance.
+	DL_PACKFLAGS_IS_WRITING_TO_EXISTING_INSTANCE = 1 << 1,	// Assumes that the out_buffer is already filled with an instance. Any dynamic data is written after this and assumed that there is space for.
+} dl_pack_flags_t;
+
 /*
 	Function: dl_txt_pack
 		Pack string of intermediate-data to binary blob that is loadable by dl_instance_load.
@@ -24,6 +30,7 @@ extern "C" {
 		out_buffer      - Buffer to pack data to.
 		out_buffer_size - Size of out_buffer.
 		produced_bytes  - Number of bytes that would have been written to out_buffer if it was large enough.
+		pack_flags        Flags to take into consideration when packing
 
 	Return:
 		DL_ERROR_OK on success. Packing an instance to a 0-sized out_buffer is thought of as a success as
@@ -34,7 +41,7 @@ extern "C" {
 	Note:
 		The instance after pack will be in current platform endian.
 */
-dl_error_t DL_DLL_EXPORT dl_txt_pack( dl_ctx_t dl_ctx, const char* txt_instance, unsigned char* out_buffer, size_t out_buffer_size, size_t* produced_bytes );
+dl_error_t DL_DLL_EXPORT dl_txt_pack( dl_ctx_t dl_ctx, const char* txt_instance, unsigned char* out_buffer, size_t out_buffer_size, size_t* produced_bytes, dl_pack_flags_t pack_flags );
 
 /*
 	Function: dl_txt_pack_calc_size
@@ -43,9 +50,10 @@ dl_error_t DL_DLL_EXPORT dl_txt_pack( dl_ctx_t dl_ctx, const char* txt_instance,
 	Parameters:
 		dl_ctx            - Context to use.
 		txt_instance      - Zero-terminated string to calculate binary blob size of.
-		out_instance_size - Size required to pack txt_instance.
+		out_instance_size - Size required to pack _pTxtData.
+		pack_flags          Flags to take into consideration when calculating packing size
 */
-dl_error_t DL_DLL_EXPORT dl_txt_pack_calc_size( dl_ctx_t dl_ctx, const char* txt_instance, size_t* out_instance_size );
+dl_error_t DL_DLL_EXPORT dl_txt_pack_calc_size( dl_ctx_t dl_ctx, const char* txt_instance, size_t* out_instance_size, dl_pack_flags_t pack_flags );
 
 /*
 	Function: dl_txt_unpack

--- a/src/dl_typelib_read_txt.cpp
+++ b/src/dl_typelib_read_txt.cpp
@@ -201,11 +201,11 @@ static void dl_load_txt_build_default_data( dl_ctx_t ctx, dl_txt_read_ctx* read_
 	def_member->offset[0] = 0;
 	def_member->offset[1] = 0;
 
-	dl_internal_str_format( def_buffer, sizeof(def_buffer), "{\"a_type_here\":{\"%s\":%.*s}}", dl_internal_member_name( ctx, member ), (int)def_len, read_state->start + def_start );
-
+	int num_want_to_write = dl_internal_str_format( def_buffer, sizeof(def_buffer), "{\"a_type_here\":{\"%s\":%.*s}}", dl_internal_member_name( ctx, member ), (int)def_len, read_state->start + def_start );
+	DL_ASSERT(num_want_to_write < sizeof(def_buffer), "Too big default value.");
 	size_t prod_bytes;
 	dl_error_t err;
-	err = dl_txt_pack( ctx, def_buffer, 0x0, 0, &prod_bytes );
+	err = dl_txt_pack( ctx, def_buffer, 0x0, 0, &prod_bytes, DL_PACKFLAGS_NONE );
 	if( err != DL_ERROR_OK )
 		dl_txt_read_failed( ctx, read_state, DL_ERROR_INVALID_DEFAULT_VALUE, "failed to pack default-value for member \"%s\" with error \"%s\"",
 															dl_internal_member_name( ctx, member ),
@@ -213,7 +213,7 @@ static void dl_load_txt_build_default_data( dl_ctx_t ctx, dl_txt_read_ctx* read_
 
 	uint8_t* pack_buffer = (uint8_t*)dl_alloc( &ctx->alloc, prod_bytes );
 
-	dl_txt_pack( ctx, def_buffer, pack_buffer, prod_bytes, 0x0 );
+	dl_txt_pack( ctx, def_buffer, pack_buffer, prod_bytes, 0x0, DL_PACKFLAGS_NONE );
 
 	// TODO: convert packed instance to typelib endian/ptrsize here!
 
@@ -1212,8 +1212,8 @@ static void dl_context_load_txt_type_library_inner( dl_ctx_t ctx, dl_txt_read_ct
 					if( sub_type == 0x0 )
 					{
 						const dl_type_desc* owner_type = dl_internal_member_owner( ctx, member );
-						dl_txt_read_failed( ctx, read_state, DL_ERROR_TYPE_NOT_FOUND, 
-											"couldn't find type for member '%s::%s'", 
+						dl_txt_read_failed( ctx, read_state, DL_ERROR_TYPE_NOT_FOUND,
+											"couldn't find type for member '%s::%s'",
 											dl_internal_type_name( ctx, owner_type ),
 											dl_internal_member_name( ctx, member ) );
 					}

--- a/src/dl_types.h
+++ b/src/dl_types.h
@@ -476,7 +476,9 @@ static inline bool dl_internal_find_enum_value( dl_ctx_t ctx, const dl_enum_desc
 	for( unsigned int j = 0; j < e->alias_count; ++j )
 	{
 		const dl_enum_alias_desc* a = dl_get_enum_alias( ctx, e, j );
-		if( strncmp( dl_internal_enum_alias_name( ctx, a ), name, name_len ) == 0 )
+		const char* alias_name = dl_internal_enum_alias_name(ctx, a);
+		size_t alias_name_len = strlen(alias_name);
+		if( name_len == alias_name_len && strncmp(alias_name, name, name_len ) == 0 )
 		{
 			*value = ctx->enum_value_descs[ a->value_index ].value;
 			return true;

--- a/src/dl_util.cpp
+++ b/src/dl_util.cpp
@@ -114,13 +114,13 @@ dl_error_t dl_util_load_from_stream( dl_ctx_t dl_ctx,       	dl_typeid_t        
 		{
 			// calc needed space
 			size_t packed_size = 0;
-			error = dl_txt_pack( dl_ctx, (char*)file_content, 0x0, 0, &packed_size );
+			error = dl_txt_pack( dl_ctx, (char*)file_content, 0x0, 0, &packed_size, DL_PACKFLAGS_NONE );
 
 			if(error != DL_ERROR_OK) { dl_free( allocator, file_content); return error; }
 
 			load_instance = (unsigned char*)dl_alloc( allocator, packed_size );
 
-			error = dl_txt_pack(dl_ctx, (char*)file_content, load_instance, packed_size, 0x0);
+			error = dl_txt_pack( dl_ctx, (char*)file_content, load_instance, packed_size, 0x0, DL_PACKFLAGS_NONE );
 
 			load_size = packed_size;
 


### PR DESCRIPTION
This changelists adds a new argument to the dl_txt_pack-function, which is a field of flags called pack-flags. There are currently two flags implemented, one for not applying defaults when packing the txt - and another that assumes that there is an instance already packed where we are packing to. The latter causes the write-position for future dynamic data to be after the already packed instance, allowing for overwriting dynamic data. This does however use more memory than needed, and you can optimize the struct by unpacking/packing it.