### PR TITLE
Added test to detect fixed size buffers, and made them growable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ if(MSVC)
 	add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /WX")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4324") # structure was padded due to alignment specifier
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4127") # conditional expression is constant
 endif()
 
 # Common directories for compiler/linker path.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ endif()
 if(MSVC)
 	add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 	add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /WX")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4324") # structure was padded due to alignment specifier
 endif()
 
 # Common directories for compiler/linker path.

--- a/src/dl.cpp
+++ b/src/dl.cpp
@@ -106,15 +106,15 @@ dl_error_t DL_DLL_EXPORT dl_instance_load_inplace( dl_ctx_t       dl_ctx,       
 
 struct CDLBinStoreContext
 {
-	CDLBinStoreContext( uint8_t* out_data, size_t out_data_size, bool is_dummy )
+	CDLBinStoreContext( uint8_t* out_data, size_t out_data_size, bool is_dummy, dl_allocator alloc )
+	    : written_ptrs(alloc)
 	{
 		dl_binary_writer_init( &writer, out_data, out_data_size, is_dummy, DL_ENDIAN_HOST, DL_ENDIAN_HOST, DL_PTR_SIZE_HOST );
-		num_written_ptrs = 0;
 	}
 
 	uintptr_t FindWrittenPtr( void* ptr )
 	{
-		for( int i = 0; i < num_written_ptrs; ++i )
+		for (int i = 0; i < written_ptrs.Len(); ++i)
 			if( written_ptrs[i].ptr == ptr )
 				return written_ptrs[i].pos;
 
@@ -123,20 +123,17 @@ struct CDLBinStoreContext
 
 	void AddWrittenPtr( const void* ptr, uintptr_t pos )
 	{
-		DL_ASSERT( num_written_ptrs < (int)DL_ARRAY_LENGTH(written_ptrs) );
-		written_ptrs[num_written_ptrs].ptr = ptr;
-		written_ptrs[num_written_ptrs].pos = pos;
-		++num_written_ptrs;
+		written_ptrs.Add( { pos, ptr } );
 	}
 
 	dl_binary_writer writer;
 
-	struct
+	struct SWrittenPtr
 	{
 		uintptr_t   pos;
 		const void* ptr;
-	} written_ptrs[128];
-	int num_written_ptrs;
+	};
+	CArrayStatic<SWrittenPtr, 128> written_ptrs;
 };
 
 static void dl_internal_store_string( const uint8_t* instance, CDLBinStoreContext* store_ctx )
@@ -422,7 +419,7 @@ dl_error_t dl_instance_store( dl_ctx_t       dl_ctx,     dl_typeid_t type_id,   
 		store_ctx_buffer_size = out_buffer_size - sizeof(dl_data_header);
 	}
 
-	CDLBinStoreContext store_context( store_ctx_buffer, store_ctx_buffer_size, store_ctx_is_dummy );
+	CDLBinStoreContext store_context( store_ctx_buffer, store_ctx_buffer_size, store_ctx_is_dummy, dl_ctx->alloc );
 
 	dl_binary_writer_reserve( &store_context.writer, type->size[DL_PTR_SIZE_HOST] );
 	store_context.AddWrittenPtr(instance, 0); // if pointer refere to root-node, it can be found at offset 0

--- a/src/dl.cpp
+++ b/src/dl.cpp
@@ -114,7 +114,7 @@ struct CDLBinStoreContext
 
 	uintptr_t FindWrittenPtr( void* ptr )
 	{
-		for (int i = 0; i < written_ptrs.Len(); ++i)
+		for (size_t i = 0; i < written_ptrs.Len(); ++i)
 			if( written_ptrs[i].ptr == ptr )
 				return written_ptrs[i].pos;
 

--- a/src/dl_convert.cpp
+++ b/src/dl_convert.cpp
@@ -6,23 +6,6 @@
 #include <dl/dl.h>
 #include <dl/dl_convert.h>
 
-template <typename T, int SIZE>
-class CArrayStatic
-{
-public:
-	T m_Storage[SIZE];
-	size_t m_nElements;
-
-	CArrayStatic() { m_nElements = 0; }
-
-	inline size_t Len()      { return m_nElements; }
-
-	void Add(const T& _Element) { DL_ASSERT(m_nElements != SIZE && "Array is full"); new(&(m_Storage[m_nElements])) T(_Element); m_nElements++; }
-
-	      T& operator[](size_t _iEl)       { DL_ASSERT(_iEl < m_nElements && "Index out of bound"); return m_Storage[_iEl]; }
-	const T& operator[](size_t _iEl) const { DL_ASSERT(_iEl < m_nElements && "Index out of bound"); return m_Storage[_iEl]; }
-};
-
 struct SInstance
 {
 	SInstance()
@@ -50,11 +33,13 @@ struct SInstance
 class SConvertContext
 {
 public:
-	SConvertContext( dl_endian_t src_endian, dl_endian_t tgt_endian, dl_ptr_size_t src_ptr_size, dl_ptr_size_t tgt_ptr_size )
+	SConvertContext( dl_endian_t src_endian, dl_endian_t tgt_endian, dl_ptr_size_t src_ptr_size, dl_ptr_size_t tgt_ptr_size, dl_allocator allocator )
 		: src_endian(src_endian)
 		, tgt_endian(tgt_endian)
 		, src_ptr_size(src_ptr_size)
 		, target_ptr_size(tgt_ptr_size)
+	    , instances(allocator)
+	    , m_lPatchOffset(allocator)
 	{}
 
 	bool IsSwapped( const uint8_t* ptr )
@@ -816,14 +801,14 @@ dl_error_t dl_internal_convert_no_header( dl_ctx_t       dl_ctx,
 	dl_binary_writer writer;
 	dl_binary_writer_init( &writer, out_instance, out_instance_size, out_instance == 0x0, src_endian, out_endian, out_ptr_size );
 
-	SConvertContext conv_ctx( src_endian, out_endian, src_ptr_size, out_ptr_size );
+	SConvertContext conv_ctx( src_endian, out_endian, src_ptr_size, out_ptr_size, dl_ctx->alloc );
 
 	conv_ctx.instances.Add(SInstance(packed_instance, root_type, 0x0, dl_make_type(DL_TYPE_ATOM_POD, DL_TYPE_STORAGE_STRUCT)));
 	dl_error_t err = dl_internal_convert_collect_instances(dl_ctx, root_type, packed_instance, packed_instance_base, conv_ctx);
 
 	// TODO: we need to sort the instances here after their offset!
 
-	SInstance* insts = conv_ctx.instances.m_Storage;
+	SInstance* insts = &conv_ctx.instances[0];
 	std::sort( insts, insts + conv_ctx.instances.Len(), dl_internal_sort_pred );
 
 	for(unsigned int i = 0; i < conv_ctx.instances.Len(); ++i)

--- a/src/dl_patch_ptr.cpp
+++ b/src/dl_patch_ptr.cpp
@@ -17,7 +17,7 @@ struct dl_patched_ptrs
 
 	bool patched( const uint8_t* addr )
 	{
-		for (unsigned int i = 0; i < addresses.Len(); ++i)
+		for (size_t i = 0; i < addresses.Len(); ++i)
 			if( addr == addresses[i] )
 				return true;
 		return false;

--- a/src/dl_patch_ptr.cpp
+++ b/src/dl_patch_ptr.cpp
@@ -3,23 +3,21 @@
 
 struct dl_patched_ptrs
 {
-	uint8_t* addresses[128];
-	unsigned int next_addr;
+	CArrayStatic<const uint8_t*, 128> addresses;
 
-	dl_patched_ptrs()
-		: next_addr(0)
+	explicit dl_patched_ptrs(dl_allocator alloc)
+	    : addresses(alloc)
 	{}
 
-	void add( uint8_t* addr )
+	void add( const uint8_t* addr )
 	{
-		DL_ASSERT( next_addr < DL_ARRAY_LENGTH( addresses ) );
 		DL_ASSERT( !patched( addr ) );
-		addresses[next_addr++] = addr;
+		addresses.Add(addr);
 	}
 
-	bool patched( uint8_t* addr )
+	bool patched( const uint8_t* addr )
 	{
-		for( unsigned int i = 0; i < next_addr; ++i )
+		for (unsigned int i = 0; i < addresses.Len(); ++i)
 			if( addr == addresses[i] )
 				return true;
 		return false;
@@ -261,7 +259,7 @@ void dl_internal_patch_member( dl_ctx_t              ctx,
 							   uintptr_t             base_address,
 							   uintptr_t             patch_distance )
 {
-	dl_patched_ptrs patched;
+	dl_patched_ptrs patched(ctx->alloc);
 	dl_internal_patch_member( ctx, member, member_data, base_address, patch_distance, &patched );
 }
 
@@ -271,7 +269,7 @@ void dl_internal_patch_instance( dl_ctx_t            ctx,
 								 uintptr_t           base_address,
 								 uintptr_t           patch_distance )
 {
-	dl_patched_ptrs patched;
+	dl_patched_ptrs patched(ctx->alloc);
 	patched.add( instance );
 
 	if( type->flags & DL_TYPE_FLAG_IS_UNION )

--- a/src/dl_txt_pack.cpp
+++ b/src/dl_txt_pack.cpp
@@ -77,12 +77,7 @@ inline double dl_strtod(const char* str, char** endptr)
 
 inline float dl_strtof(const char* str, char** endptr)
 {
-#if defined(_MSC_VER) && _MSC_VER < 1800 // strtof was defined first in MSVC2013
-	float res = (float)strtod(str, endptr);
-#else
 	float res = strtof(str, endptr);
-#endif
-
 	if(str == *endptr)
 	{
 		float sign = 1.0f;
@@ -1147,8 +1142,8 @@ static dl_error_t dl_txt_pack_finalize_subdata( dl_ctx_t dl_ctx, dl_txt_pack_ctx
 
 		dl_txt_eat_char( dl_ctx, &packctx->read_ctx, ':' );
 
-		int subdata_item = -1;
-		for (int i = 0; i < packctx->subdata.Len(); ++i)
+		size_t subdata_item = std::numeric_limits<size_t>::max();
+		for (size_t i = 0; i < packctx->subdata.Len(); ++i)
 		{
 			if( packctx->subdata[i].name.len != subdata_name.len )
 				continue;
@@ -1160,7 +1155,7 @@ static dl_error_t dl_txt_pack_finalize_subdata( dl_ctx_t dl_ctx, dl_txt_pack_ctx
 			}
 		}
 
-		if( subdata_item < 0 )
+		if (subdata_item == std::numeric_limits<size_t>::max())
 			dl_txt_read_failed( dl_ctx, &packctx->read_ctx, DL_ERROR_MALFORMED_DATA, "non-used subdata." );
 		const dl_type_desc* type = packctx->subdata[subdata_item].type;
 
@@ -1181,7 +1176,7 @@ static dl_error_t dl_txt_pack_finalize_subdata( dl_ctx_t dl_ctx, dl_txt_pack_ctx
 
 	dl_txt_eat_char( dl_ctx, &packctx->read_ctx, '}' );
 
-	for (int i = 0; i < packctx->subdata.Len(); ++i)
+	for (size_t i = 0; i < packctx->subdata.Len(); ++i)
 	{
 		bool found = false;
 		for( size_t j = 0; j < subinstances.Len(); ++j )

--- a/src/dl_txt_pack.cpp
+++ b/src/dl_txt_pack.cpp
@@ -1176,7 +1176,7 @@ static dl_error_t dl_txt_pack_finalize_subdata( dl_ctx_t dl_ctx, dl_txt_pack_ctx
 
 	dl_txt_eat_char( dl_ctx, &packctx->read_ctx, '}' );
 
-	for (size_t i = 0; i < packctx->subdata.Len(); ++i)
+	for( size_t i = 0; i < packctx->subdata.Len(); ++i )
 	{
 		bool found = false;
 		for( size_t j = 0; j < subinstances.Len(); ++j )

--- a/src/dl_txt_unpack.cpp
+++ b/src/dl_txt_unpack.cpp
@@ -549,7 +549,7 @@ static void dl_txt_unpack_write_subdata_ptr( dl_ctx_t            dl_ctx,
 	if( offset == 0 )
 		return;
 
-	for( int i = 0; i < unpack_ctx->ptrs.Len(); ++i )
+	for (size_t i = 0; i < unpack_ctx->ptrs.Len(); ++i)
 		if( unpack_ctx->ptrs[i].offset == offset )
 			return;
 

--- a/src/dl_types.h
+++ b/src/dl_types.h
@@ -16,6 +16,7 @@
 #include "dl_swap.h"
 
 #include <stdarg.h> // for va_list
+#include <new> // for inplace new
 
 #define DL_BITMASK(_Bits)                   ( (1ULL << (_Bits)) - 1ULL )
 #define DL_BITRANGE(_MinBit,_MaxBit)		( ((1ULL << (_MaxBit)) | ((1ULL << (_MaxBit))-1ULL)) ^ ((1ULL << (_MinBit))-1ULL) )
@@ -312,6 +313,84 @@ struct dl_substr
 {
 	const char* str;
 	int len;
+};
+
+// A growable array using a stack buffer while small. Use it to avoid dynamic allocations while the stack is big enough, but fall back to heap if it grows past the wanted stack size
+template <typename T, int SIZE>
+class CArrayStatic
+{
+private:
+	inline void GrowIfNeeded()
+	{
+		if (m_nElements >= m_nCapacity)
+		{
+			size_t curr_size = sizeof(T) * m_nCapacity;
+			if (m_Ptr != &m_Storage[0])
+			{
+				m_Ptr = reinterpret_cast<T*>(dl_realloc(&m_Allocator, m_Ptr, curr_size * 2, curr_size));
+			}
+			else
+			{
+				void* new_mem = dl_alloc(&m_Allocator, curr_size * 2);
+				memcpy(new_mem, m_Storage, curr_size);
+				m_Ptr = reinterpret_cast<T*>(new_mem);
+			}
+			m_nCapacity *= 2;
+		}
+	}
+
+public:
+	T* m_Ptr;
+	T m_Storage[SIZE];
+	size_t m_nElements;
+	size_t m_nCapacity;
+	dl_allocator m_Allocator;
+
+	explicit CArrayStatic(dl_allocator allocator)
+	{
+		m_nElements = 0;
+		m_nCapacity = SIZE;
+		m_Ptr = &m_Storage[0];
+		m_Allocator = allocator;
+	}
+
+	~CArrayStatic()
+	{
+		if (m_Ptr != &m_Storage[0])
+		{
+			dl_free(&m_Allocator, m_Ptr);
+		}
+	}
+
+	inline size_t Len()
+	{
+		return m_nElements;
+	}
+
+	void Add(const T& _Element)
+	{
+		GrowIfNeeded();
+		new (&m_Ptr[m_nElements]) T(_Element);
+		m_nElements++;
+	}
+
+	void Add(T&& _Element)
+	{
+		GrowIfNeeded();
+		new (&m_Ptr[m_nElements]) T(std::move(_Element));
+		m_nElements++;
+	}
+
+	T& operator[](size_t _iEl)
+	{
+		DL_ASSERT(_iEl < m_nElements && "Index out of bound");
+		return m_Ptr[_iEl];
+	}
+	const T& operator[](size_t _iEl) const
+	{
+		DL_ASSERT(_iEl < m_nElements && "Index out of bound");
+		return m_Ptr[_iEl];
+	}
 };
 
 #if defined( __GNUC__ )

--- a/tests/dl_tests_ptr.cpp
+++ b/tests/dl_tests_ptr.cpp
@@ -207,3 +207,21 @@ TYPED_TEST(DLBase, ptr_array)
 	EXPECT_NE( loaded[0].arr[0], loaded[0].arr[1] );
 	EXPECT_EQ( loaded[0].arr[0], loaded[0].arr[2] );
 }
+
+TYPED_TEST(DLBase, ptr_chain_long)
+{
+	PtrChain ptrs[1024];
+	for (size_t i = 0; i < DL_ARRAY_LENGTH(ptrs) - 1; ++i)
+		ptrs[i] = { (uint32_t) i, &ptrs[i + 1] };
+	ptrs[DL_ARRAY_LENGTH(ptrs) - 1] = { DL_ARRAY_LENGTH(ptrs) - 1, &ptrs[0] };
+
+	PtrChain loaded[1024];
+
+	this->do_the_round_about(PtrChain::TYPE_ID, &ptrs, &loaded, sizeof(loaded));
+
+	for (size_t i = 0; i < DL_ARRAY_LENGTH(ptrs) - 1; ++i)
+	{
+		EXPECT_EQ(loaded[i].Next, &loaded[i + 1]);
+		EXPECT_EQ(loaded[i].Int, i);
+	}
+}


### PR DESCRIPTION
Stack buffers are a great way to optimize while the payload is small, but only asserting on the size is evil in Release and emitting "malformed data" isn't nice neither since the data is just big. So now these buffers grow when overflowing the chosen stack limits.