### PR TITLE
Created failing unittest about pointers to structs

### DIFF
--- a/bam.lua
+++ b/bam.lua
@@ -66,37 +66,29 @@ function get_compiler()
   compiler = ScriptArgs["compiler"]
 
   if family == "windows" then
-    local has_msvs14 = os.getenv('VS140COMNTOOLS') ~= nil
-    local has_msvs10 = os.getenv('VS100COMNTOOLS') ~= nil
-    local has_msvs8  = os.getenv('VS80COMNTOOLS') ~= nil
+    local has_msvs = {}
+    for i=8,30 do
+      has_msvs[i] = os.getenv('VS' .. i .. '0COMNTOOLS') ~= nil
+    end
 
     if compiler == nil then
-      -- set default compiler
-      if     has_msvs14 then compiler = 'msvs14'
-      elseif has_msvs10 then compiler = 'msvs10'
-      elseif has_msvs8  then compiler = 'msvs8'
-      else   compiler = nil
-      end
-    elseif compiler == 'msvs14' then
-      if not has_msvs14 then
-        print( compiler  .. ' is not installed on this machine' )
-        os.exit(1)
-      end
-    elseif compiler == 'msvs10' then
-      if not has_msvs10 then
-        print( compiler  .. ' is not installed on this machine' )
-        os.exit(1)
-      end
-    elseif compiler == 'msvs8' then
-      if not has_msvs8 then
-        print( compiler  .. ' is not installed on this machine' )
-        os.exit(1)
+      for i=30,8,-1 do
+        if has_msvs[i] then
+          compiler = 'msvs' .. i
+          break
+        end
       end
     else
-      print( compiler  .. ' is not installed on this machine' )
-      os.exit(1)
+      for i=8,30 do
+        if compiler == ('msvs' .. i) then
+          if not has_msvs[i] then
+            print( compiler  .. ' is not installed on this machine' )
+            os.exit(1)
+          end
+          break
+        end
+      end
     end
-  else
     if compiler == nil then
       compiler = 'gcc'
     end

--- a/tests/dl_tests_dl.cpp
+++ b/tests/dl_tests_dl.cpp
@@ -133,7 +133,7 @@ TYPED_TEST(DLBase, bug5)
 	EXPECT_EQ(2U, loaded[0].array[0].Int);
 }
 
-TYPED_TEST( DLBase, bug6 )
+TYPED_TEST( DLBase, DISABLED_bug6 )
 {
 	// testing that pointers to structs work, and doesn't create redundant data
 	PtrChain arr[2];
@@ -141,8 +141,8 @@ TYPED_TEST( DLBase, bug6 )
 	arr[0].Next = &arr[1];
 	arr[1].Int  = 1;
 	arr[1].Next = &arr[0];
-	BugTest5 original;
 
+	BugTest5 original;
 	original.array.count = 2;
 	original.array.data  = &arr[0];
 
@@ -154,9 +154,9 @@ TYPED_TEST( DLBase, bug6 )
 	EXPECT_EQ( &loaded[0].array[1], loaded[0].array[1].Next->Next );
 
 	size_t circular_store_size;
-	EXPECT_DL_ERR_OK( dl_instance_calc_size( this->Ctx, arr[0].TYPE_ID, &arr[0], &single_ptr_store_size ) );
+	EXPECT_DL_ERR_OK( dl_instance_calc_size(this->Ctx, original.TYPE_ID, &original, &circular_store_size) );
 	size_t single_ptr_store_size;
-	EXPECT_DL_ERR_OK( dl_instance_calc_size( this->Ctx, original.TYPE_ID, &original, &circular_store_size ) );
+	EXPECT_DL_ERR_OK( dl_instance_calc_size(this->Ctx, arr[0].TYPE_ID, &arr[0], &single_ptr_store_size) );
 	EXPECT_EQ( circular_store_size, single_ptr_store_size + sizeof( original.array ) + sizeof( arr[0] ) );
 }
 

--- a/tests/dl_tests_dl.cpp
+++ b/tests/dl_tests_dl.cpp
@@ -113,6 +113,34 @@ TYPED_TEST(DLBase, bug4)
 	}
 }
 
+TYPED_TEST( DLBase, bug6 )
+{
+	// testing that pointers to structs work, and doesn't create redundant data
+	PtrChain arr[2];
+	arr[0].Int  = 2;
+	arr[0].Next = &arr[1];
+	arr[1].Int  = 1;
+	arr[1].Next = &arr[0];
+	BugTest5 original;
+
+	original.array.count = 2;
+	original.array.data  = &arr[0];
+
+	BugTest5 loaded[1024];
+
+	this->do_the_round_about( original.TYPE_ID, &original, &loaded, sizeof( loaded ) );
+
+	EXPECT_EQ( &loaded[0].array[0], loaded[0].array[0].Next->Next );
+	EXPECT_EQ( &loaded[0].array[1], loaded[0].array[1].Next->Next );
+	size_t circular_store_size;
+
+}
+	EXPECT_EQ( circular_store_size, single_ptr_store_size + sizeof( original.array ) + sizeof( arr[0] ) );
+	EXPECT_DL_ERR_OK( dl_instance_calc_size( this->Ctx, arr[0].TYPE_ID, &arr[0], &single_ptr_store_size ) );
+	size_t single_ptr_store_size;
+
+	EXPECT_DL_ERR_OK( dl_instance_calc_size( this->Ctx, original.TYPE_ID, &original, &circular_store_size ) );
+
 TYPED_TEST(DLBase, str_before_array_bug)
 {
 	// Test for bug #7, where string written before array would lead to mis-alignment of the array.


### PR DESCRIPTION
If I understand the current design then all pointers need to reference payloads in the "__subdata" section, so pointing to a member struct or a struct inside an array means the data gets duplicated.

I have no fix for this because I'm not sure which way to best tag the structs in DL's json.