### PR TITLE
Added merging of identical strings

### DIFF
--- a/bam.lua
+++ b/bam.lua
@@ -66,37 +66,29 @@ function get_compiler()
   compiler = ScriptArgs["compiler"]
 
   if family == "windows" then
-    local has_msvs14 = os.getenv('VS140COMNTOOLS') ~= nil
-    local has_msvs10 = os.getenv('VS100COMNTOOLS') ~= nil
-    local has_msvs8  = os.getenv('VS80COMNTOOLS') ~= nil
+    local has_msvs = {}
+    for i=8,30 do
+      has_msvs[i] = os.getenv('VS' .. i .. '0COMNTOOLS') ~= nil
+    end
 
     if compiler == nil then
-      -- set default compiler
-      if     has_msvs14 then compiler = 'msvs14'
-      elseif has_msvs10 then compiler = 'msvs10'
-      elseif has_msvs8  then compiler = 'msvs8'
-      else   compiler = nil
-      end
-    elseif compiler == 'msvs14' then
-      if not has_msvs14 then
-        print( compiler  .. ' is not installed on this machine' )
-        os.exit(1)
-      end
-    elseif compiler == 'msvs10' then
-      if not has_msvs10 then
-        print( compiler  .. ' is not installed on this machine' )
-        os.exit(1)
-      end
-    elseif compiler == 'msvs8' then
-      if not has_msvs8 then
-        print( compiler  .. ' is not installed on this machine' )
-        os.exit(1)
+      for i=30,8,-1 do
+        if has_msvs[i] then
+          compiler = 'msvs' .. i
+          break
+        end
       end
     else
-      print( compiler  .. ' is not installed on this machine' )
-      os.exit(1)
+      for i=8,30 do
+        if compiler == ('msvs' .. i) then
+          if not has_msvs[i] then
+            print( compiler  .. ' is not installed on this machine' )
+            os.exit(1)
+          end
+          break
+        end
+      end
     end
-  else
     if compiler == nil then
       compiler = 'gcc'
     end

--- a/src/dl.cpp
+++ b/src/dl.cpp
@@ -108,6 +108,7 @@ struct CDLBinStoreContext
 {
 	CDLBinStoreContext( uint8_t* out_data, size_t out_data_size, bool is_dummy, dl_allocator alloc )
 	    : written_ptrs(alloc)
+		, strings(alloc)
 	{
 		dl_binary_writer_init( &writer, out_data, out_data_size, is_dummy, DL_ENDIAN_HOST, DL_ENDIAN_HOST, DL_PTR_SIZE_HOST );
 	}
@@ -126,6 +127,15 @@ struct CDLBinStoreContext
 		written_ptrs.Add( { pos, ptr } );
 	}
 
+	uint32_t GetStringOffset(const char* str, uint32_t length, uint32_t hash)
+	{
+		for (size_t i = 0; i < strings.Len(); ++i)
+			if (strings[i].hash == hash && strings[i].length == length && strcmp(str, strings[i].str) == 0)
+				return strings[i].offset;
+
+		return 0;
+	}
+
 	dl_binary_writer writer;
 
 	struct SWrittenPtr
@@ -134,6 +144,15 @@ struct CDLBinStoreContext
 		const void* ptr;
 	};
 	CArrayStatic<SWrittenPtr, 128> written_ptrs;
+
+	struct SString
+	{
+		const char* str;
+		uint32_t length;
+		uint32_t hash;
+		uint32_t offset;
+	};
+	CArrayStatic<SString, 128> strings;
 };
 
 static void dl_internal_store_string( const uint8_t* instance, CDLBinStoreContext* store_ctx )
@@ -144,11 +163,18 @@ static void dl_internal_store_string( const uint8_t* instance, CDLBinStoreContex
 		dl_binary_writer_write( &store_ctx->writer, &DL_NULL_PTR_OFFSET[ DL_PTR_SIZE_HOST ], sizeof(uintptr_t) );
 		return;
 	}
-	uintptr_t pos = dl_binary_writer_tell( &store_ctx->writer );
-	dl_binary_writer_seek_end( &store_ctx->writer );
-	uintptr_t offset = dl_binary_writer_tell( &store_ctx->writer );
-	dl_binary_writer_write( &store_ctx->writer, str, strlen(str) + 1 );
-	dl_binary_writer_seek_set( &store_ctx->writer, pos );
+	uint32_t hash = dl_internal_hash_string(str);
+	uint32_t length = (uint32_t) strlen(str);
+	uintptr_t offset = store_ctx->GetStringOffset(str, length, hash);
+	if (offset == 0) // Merge identical strings
+	{
+		uintptr_t pos = dl_binary_writer_tell(&store_ctx->writer);
+		dl_binary_writer_seek_end(&store_ctx->writer);
+		offset = dl_binary_writer_tell(&store_ctx->writer);
+		dl_binary_writer_write(&store_ctx->writer, str, length + 1);
+		store_ctx->strings.Add( {str, length, hash, (uint32_t) offset} );
+		dl_binary_writer_seek_set(&store_ctx->writer, pos);
+	}
 	dl_binary_writer_write( &store_ctx->writer, &offset, sizeof(uintptr_t) );
 }
 

--- a/src/dl_convert.cpp
+++ b/src/dl_convert.cpp
@@ -815,8 +815,12 @@ dl_error_t dl_internal_convert_no_header( dl_ctx_t       dl_ctx,
 	SInstance* insts = &conv_ctx.instances[0];
 	std::sort( insts, insts + conv_ctx.instances.Len(), dl_internal_sort_pred );
 
+	const void* last_address = 0;
 	for(unsigned int i = 0; i < conv_ctx.instances.Len(); ++i)
 	{
+		if (dl_type_storage_t((conv_ctx.instances[i].type_id & DL_TYPE_STORAGE_MASK) >> DL_TYPE_STORAGE_MIN_BIT) == DL_TYPE_STORAGE_STR && last_address == conv_ctx.instances[i].address)
+			continue; // Merge identical strings
+		last_address = conv_ctx.instances[i].address;
 		err = dl_internal_convert_write_instance( dl_ctx, conv_ctx.instances[i], &conv_ctx.instances[i].offset_after_patch, conv_ctx, &writer );
 		if(err != DL_ERROR_OK)
 			return err;

--- a/tests/dl_tests_array.cpp
+++ b/tests/dl_tests_array.cpp
@@ -56,7 +56,7 @@ TYPED_TEST(DLBase, array_with_sub_array2)
 
 TYPED_TEST(DLBase, array_string)
 {
-	const char* array_data[] = { "I like", "the", "1337 ", "cowbells of doom!" }; // TODO: test string-arrays with , in strings.
+	const char* array_data[] = { "I like", "the", "1337 ", "cowbells of doom!" };
 	StringArray original = { { array_data, DL_ARRAY_LENGTH(array_data) } };
 	StringArray loaded[10];
 
@@ -66,6 +66,32 @@ TYPED_TEST(DLBase, array_string)
 	EXPECT_STREQ(original.Strings[1], loaded[0].Strings[1]);
 	EXPECT_STREQ(original.Strings[2], loaded[0].Strings[2]);
 	EXPECT_STREQ(original.Strings[3], loaded[0].Strings[3]);
+}
+
+TYPED_TEST(DLBase, array_string_merge)
+{
+	const char* array_data[] = { "cowbell, cowbell", "cowbell, cowbell" };
+	StringArray original = { { array_data, DL_ARRAY_LENGTH(array_data) } };
+	StringArray loaded[20];
+
+	this->do_the_round_about(StringArray::TYPE_ID, &original, &loaded[0], sizeof(loaded) / 2);
+
+	EXPECT_STREQ(original.Strings[0], loaded[0].Strings[0]);
+	EXPECT_STREQ(original.Strings[1], loaded[0].Strings[1]);
+
+	const char* array_data_2[] = { "cowbell 1", "cowbell 2" };
+	original = { { array_data_2, DL_ARRAY_LENGTH(array_data_2) } };
+
+	this->do_the_round_about(StringArray::TYPE_ID, &original, &loaded[10], sizeof(loaded) / 2);
+
+	EXPECT_STREQ(original.Strings[0], loaded[10].Strings[0]);
+	EXPECT_STREQ(original.Strings[1], loaded[10].Strings[1]);
+
+	size_t merged_store_size = 0; // Two long but identical strings, should be merged
+	EXPECT_DL_ERR_OK(dl_instance_calc_size(this->Ctx, loaded[0].TYPE_ID, &loaded[0], &merged_store_size));
+	size_t unique_store_size = 0; // Two shorter and different strings, should not be merged
+	EXPECT_DL_ERR_OK(dl_instance_calc_size(this->Ctx, loaded[10].TYPE_ID, &loaded[10], &unique_store_size));
+	EXPECT_LT(merged_store_size, unique_store_size); // Check that long merged strings take less memory than short unique strings
 }
 
 TYPED_TEST(DLBase, array_string_null)
@@ -84,7 +110,7 @@ TYPED_TEST(DLBase, array_string_null)
 
 TYPED_TEST(DLBase, array_string_with_commas)
 {
-	const char* array_data[] = { "I li,ke", "the", "13,37 ", "cowbe,lls of doom!" }; // TODO: test string-arrays with , in strings.
+	const char* array_data[] = { "I li,ke", "the", "13,37 ", "cowbe,lls of doom!" };
 	StringArray original = { { array_data, DL_ARRAY_LENGTH(array_data) } };
 	StringArray loaded[10];
 


### PR DESCRIPTION
A first stab at https://github.com/wc-duck/datalibrary/issues/14
I don't think merging strings need an option, they are const. Also note that this initial change will only merge strings when doing binary store, and not when doing text pack. I hope developing in iterations is okay. :)