### PR TITLE
Pointer to inline array fixes

### DIFF
--- a/src/dl_txt_unpack.cpp
+++ b/src/dl_txt_unpack.cpp
@@ -630,8 +630,19 @@ static void dl_txt_unpack_write_member_subdata(dl_ctx_t dl_ctx, dl_txt_unpack_ct
 														   member->inline_array_cnt(),
 														   dl_internal_find_type( dl_ctx, member->type_id ) );
 				break;
+				case DL_TYPE_STORAGE_STRUCT:
+				{
+					const dl_type_desc* subtype = dl_internal_find_type( dl_ctx, member->type_id );
+					if( subtype->flags & DL_TYPE_FLAG_HAS_SUBDATA )
+					{
+						for( uint32_t i = 0; i < member->inline_array_cnt(); ++i )
+							dl_txt_unpack_write_subdata( dl_ctx, unpack_ctx, writer, subtype, member_data + i * subtype->size[DL_PTR_SIZE_HOST] );
+					}
+				}
+				break;
 				default:
-					DL_ASSERT(false);
+					// ignore ...
+			    break;
 			}
 		}
 		break;

--- a/tests/dl_tests_ptr.cpp
+++ b/tests/dl_tests_ptr.cpp
@@ -225,3 +225,57 @@ TYPED_TEST(DLBase, ptr_chain_long)
 		EXPECT_EQ(loaded[i].Int, i);
 	}
 }
+
+TYPED_TEST( DLBase, ptr_inline_array )
+{
+	WithInlineArray wi  = { { 1, 2, 3 } };
+	ptr_inline_array p1 = { &wi };
+
+	size_t loaded_size = this->calculate_unpack_size(ptr_inline_array::TYPE_ID, &p1);
+	ptr_inline_array *loaded = (ptr_inline_array*)malloc(loaded_size);
+	this->do_the_round_about(ptr_inline_array::TYPE_ID, &p1, loaded, loaded_size);
+
+	EXPECT_EQ(1u, loaded->ptr->Array[0]);
+	EXPECT_EQ(2u, loaded->ptr->Array[1]);
+	EXPECT_EQ(3u, loaded->ptr->Array[2]);
+
+	free(loaded);
+}
+
+TYPED_TEST( DLBase, ptr_inline_array2 )
+{
+	WithInlineStructArray wi = { { { 1, 2 }, { 3, 4 }, { 5, 6 } } };
+	ptr_inline_array2 p1 = { &wi };
+
+	size_t loaded_size = this->calculate_unpack_size(ptr_inline_array2::TYPE_ID, &p1);
+	ptr_inline_array2 *loaded = (ptr_inline_array2*)malloc(loaded_size);
+	this->do_the_round_about(ptr_inline_array2::TYPE_ID, &p1, loaded, loaded_size);
+
+	EXPECT_EQ(1u, loaded->ptr->Array[0].Int1);
+	EXPECT_EQ(2u, loaded->ptr->Array[0].Int2);
+	EXPECT_EQ(3u, loaded->ptr->Array[1].Int1);
+	EXPECT_EQ(4u, loaded->ptr->Array[1].Int2);
+	EXPECT_EQ(5u, loaded->ptr->Array[2].Int1);
+	EXPECT_EQ(6u, loaded->ptr->Array[2].Int2);
+
+	free(loaded);
+}
+
+
+TYPED_TEST( DLBase, ptr_struct_inline_array_ptr )
+{
+	Pods2 p2 = { 1, 2 };
+	inline_array_pod_ptr ipr = { { { &p2 }, { &p2 } } };
+	ptr_struct_inline_array_ptr psiap = { &ipr };
+
+	size_t loaded_size = this->calculate_unpack_size(ptr_struct_inline_array_ptr::TYPE_ID, &psiap);
+	ptr_struct_inline_array_ptr *loaded = (ptr_struct_inline_array_ptr*)malloc(loaded_size);
+	this->do_the_round_about(ptr_struct_inline_array_ptr::TYPE_ID, &psiap, loaded, loaded_size);
+
+	EXPECT_EQ(1u, loaded->ptr->inlarr[0].PodPtr1->Int1);
+	EXPECT_EQ(2u, loaded->ptr->inlarr[0].PodPtr1->Int2);
+	EXPECT_EQ(1u, loaded->ptr->inlarr[1].PodPtr1->Int1);
+	EXPECT_EQ(2u, loaded->ptr->inlarr[1].PodPtr1->Int2);
+	
+	free(loaded);
+}

--- a/tests/dl_tests_union.cpp
+++ b/tests/dl_tests_union.cpp
@@ -151,6 +151,23 @@ TYPED_TEST(DLBase, union_with_ptr)
 	EXPECT_EQ( original.value.p1->f64, loaded[0].value.p1->f64 );
 }
 
+TYPED_TEST(DLBase, union_with_inline_arr_ptr)
+{
+	WithInlineArray wi  = { { 1, 2, 3 } };
+	test_union_ptr original;
+	original.value.p3 = &wi;
+	original.type = test_union_ptr_type_p3;
+
+	test_union_ptr DL_ALIGN(8) loaded[10];
+
+	this->do_the_round_about( test_union_ptr::TYPE_ID, &original, loaded, sizeof(loaded) );
+
+	EXPECT_EQ( original.type, loaded[0].type );
+	EXPECT_EQ( 1u, original.value.p3->Array[0]);
+	EXPECT_EQ( 2u, original.value.p3->Array[1]);
+	EXPECT_EQ( 3u, original.value.p3->Array[2]);
+}
+
 // TODO: add test in dl_tests_txt.cpp of setting more than one member in txt data that it is an error.
 
 TYPED_TEST(DLBase, union_in_inline_array)

--- a/tests/unittest.tld
+++ b/tests/unittest.tld
@@ -78,6 +78,7 @@
 		"MorePods"     : { "members" : [ { "name" : "Pods1", "type" : "Pods"  },  { "name" : "Pods2", "type" : "Pods" }   ] },
 		"Pods2"        : { "members" : [ { "name" : "Int1",  "type" : "uint32" }, { "name" : "Int2",  "type" : "uint32" } ] },
 		"Pod2InStruct" : { "members" : [ { "name" : "Pod1",  "type" : "Pods2" },  { "name" : "Pod2",  "type" : "Pods2" }  ] },
+		"PodPtr" : { "members" : [ { "name" : "PodPtr1",  "type" : "Pods2*" } ] },
 
 		"Pod2InStructInStruct"        : { "members" : [ { "name" : "p2struct", "type" : "Pod2InStruct" } ] },
 		"WithInlineArray"             : { "members" : [ { "name" : "Array",    "type" : "uint32[3]" } ] },
@@ -155,6 +156,26 @@
 		"ptr_array" : {
 			"members" : [
 				{ "name" : "arr", "type" : "Pods2*[]" }
+			]
+		},
+		"ptr_inline_array" : {
+			"members" : [
+				{"name" : "ptr", "type" : "WithInlineArray*"}
+			]
+		},
+		"ptr_inline_array2" : {
+			"members" : [
+				{"name" : "ptr", "type" : "WithInlineStructArray*"}
+			]
+		},
+		"inline_array_pod_ptr" : {
+			"members" : [
+				{"name" : "inlarr", "type" : "PodPtr[2]"}
+			]
+		},
+		"ptr_struct_inline_array_ptr" : {
+			"members" : [
+				{"name" : "ptr", "type" : "inline_array_pod_ptr*"}
 			]
 		},
 
@@ -403,7 +424,8 @@
 		"test_union_ptr" : {
 			"members" : [
 				{ "name" : "p1", "type" : "Pods*" },
-				{ "name" : "p2", "type" : "SubString*" }
+				{ "name" : "p2", "type" : "SubString*" },
+				{ "name" : "p3", "type" : "WithInlineArray*" }
 			]
 		},
 		"test_has_union_array": {


### PR DESCRIPTION
dl_txt_unpack was missing a case for pointer to inline array of structs and had an assert for pointer to inline array of pods which I removed. Added a few tests to cover the issues I ran into.