### PR TITLE
Fast pointer patching plus txt_unpack for "loaded" data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,3 +79,78 @@ if (DATA_LIBRARY_PACK)
 	add_executable(dlpack ${DLPACK_SRCS})
 	target_link_libraries(dlpack PRIVATE data_library)
 endif()
+
+# Data Library Tests (dltests) - optional, defaulted to also build.
+option(DATA_LIBRARY_TESTS "Build dltests." ON)
+if (DATA_LIBRARY_TESTS)
+	set(GTEST_SRCS
+		external/gtest/src/gtest-death-test.cc
+		external/gtest/src/gtest-filepath.cc
+		external/gtest/src/gtest-matchers.cc
+		external/gtest/src/gtest-port.cc
+		external/gtest/src/gtest-printers.cc
+		external/gtest/src/gtest-test-part.cc
+		external/gtest/src/gtest-typed-test.cc
+		external/gtest/src/gtest.cc
+		external/gtest/src/gtest_main.cc)
+
+	set(GTEST_HDRS
+		external/gtest/src/gtest-internal-inl.h
+		external/gtest/include/gtest/gtest-death-test.h
+		external/gtest/include/gtest/gtest-matchers.h
+		external/gtest/include/gtest/gtest-message.h
+		external/gtest/include/gtest/gtest-param-test.h
+		external/gtest/include/gtest/gtest-printers.h
+		external/gtest/include/gtest/gtest-spi.h
+		external/gtest/include/gtest/gtest-test-part.h
+		external/gtest/include/gtest/gtest-typed-test.h
+		external/gtest/include/gtest/gtest.h
+		external/gtest/include/gtest/gtest_pred_impl.h
+		external/gtest/include/gtest/gtest_prod.h
+		external/gtest/include/gtest/internal/gtest-death-test-internal.h
+		external/gtest/include/gtest/internal/gtest-filepath.h
+		external/gtest/include/gtest/internal/gtest-internal.h
+		external/gtest/include/gtest/internal/gtest-param-util.h
+		external/gtest/include/gtest/internal/gtest-port-arch.h
+		external/gtest/include/gtest/internal/gtest-port.h
+		external/gtest/include/gtest/internal/gtest-string.h
+		external/gtest/include/gtest/internal/gtest-type-util.h)
+
+	add_library(gtest STATIC ${GTEST_SRCS} ${GTEST_HDRS})
+	include_directories(src include tool/dlpack external/gtest/include external/gtest/)
+
+	set(DLTESTS_SRCS
+		tests/dl_tests_array.cpp
+		tests/dl_tests_base.cpp
+		tests/dl_tests_bitfield.cpp
+		tests/dl_tests_dl.cpp
+		tests/dl_tests_enum.cpp
+		tests/dl_tests_error.cpp
+		tests/dl_tests_inline_array.cpp
+		tests/dl_tests_ptr.cpp
+		tests/dl_tests_reflect.cpp
+		tests/dl_tests_string.cpp
+		tests/dl_tests_struct.cpp
+		tests/dl_tests_txt.cpp
+		tests/dl_tests_typelib.cpp
+		tests/dl_tests_union.cpp
+		tests/dl_tests_util.cpp	
+	)
+
+	add_executable(dltests ${DLTESTS_SRCS})
+	target_link_libraries(dltests PRIVATE gtest data_library)
+	include_directories(src include tool/dlpack external/gtest/include local)
+endif()
+
+
+# Data Library Tests (dltests) - optional, defaulted to also build.
+option(DATA_LIBRARY_BENCHMARK "Build dlbench." ON)
+if (DATA_LIBRARY_BENCHMARK)
+	set(DLBENCH_SRCS
+		benchmark/dlbench.cpp
+	)
+
+	add_executable(dlbench ${DLBENCH_SRCS})
+	target_link_libraries(dlbench PRIVATE data_library)
+	include_directories(src include build/local)
+endif()

--- a/include/dl/dl_txt.h
+++ b/include/dl/dl_txt.h
@@ -83,10 +83,9 @@ dl_error_t DL_DLL_EXPORT dl_txt_unpack( dl_ctx_t       dl_ctx,           dl_type
 	Note:
 	    A loaded instance to unpack is required to be in current platform endian, if not DL_ERROR_ENDIAN_ERROR will be returned.
 */
-dl_error_t DL_DLL_EXPORT dl_txt_unpack_loaded( dl_ctx_t dl_ctx,        dl_typeid_t type,
-                                               const unsigned char* loaded_instance,
-                                               char* out_txt_instance, size_t out_txt_instance_size,
-                                               size_t* produced_bytes );
+dl_error_t DL_DLL_EXPORT dl_txt_unpack_loaded( dl_ctx_t dl_ctx,              dl_typeid_t type,
+                                               const void* loaded_instance,  char* out_txt_instance,
+	                                           size_t out_txt_instance_size, size_t* produced_bytes );
 
 /*
 	Function: dl_txt_unpack_calc_size
@@ -103,7 +102,7 @@ dl_error_t DL_DLL_EXPORT dl_txt_unpack_loaded( dl_ctx_t dl_ctx,        dl_typeid
 		Packed instance to unpack is required to be in current platform endian, if not DL_ERROR_ENDIAN_ERROR will be returned.
 */
 dl_error_t DL_DLL_EXPORT dl_txt_unpack_calc_size( dl_ctx_t             dl_ctx,               dl_typeid_t type,
-                                                  unsigned char* packed_instance,            size_t      packed_instance_size,
+                                                  unsigned char*       packed_instance,      size_t      packed_instance_size,
                                                   size_t*              out_txt_instance_size );
 
 /*
@@ -119,8 +118,8 @@ dl_error_t DL_DLL_EXPORT dl_txt_unpack_calc_size( dl_ctx_t             dl_ctx,  
 	Note:
 	    Packed instance to unpack is required to be in current platform endian, if not DL_ERROR_ENDIAN_ERROR will be returned.
 */
-dl_error_t DL_DLL_EXPORT dl_txt_unpack_loaded_calc_size( dl_ctx_t dl_ctx, dl_typeid_t type,
-                                                         unsigned char* loaded_instance, size_t* out_txt_instance_size );
+dl_error_t DL_DLL_EXPORT dl_txt_unpack_loaded_calc_size( dl_ctx_t dl_ctx,             dl_typeid_t type,
+                                                         const void* loaded_instance, size_t* out_txt_instance_size );
 
 #ifdef __cplusplus
 }

--- a/include/dl/dl_txt.h
+++ b/include/dl/dl_txt.h
@@ -49,7 +49,7 @@ dl_error_t DL_DLL_EXPORT dl_txt_pack_calc_size( dl_ctx_t dl_ctx, const char* txt
 
 /*
 	Function: dl_txt_unpack
-		Unpack binary packed instance to text-format.
+		Unpack a packed binary (with header and offsets) instance to text-format.
 
 	Parameters:
 		dl_ctx                - Context to use.
@@ -61,16 +61,36 @@ dl_error_t DL_DLL_EXPORT dl_txt_pack_calc_size( dl_ctx_t dl_ctx, const char* txt
 		produced_bytes        - Number of bytes that would have been written to out_txt_instance if it was large enough.
 
 	Note:
-		Packed instance to unpack is required to be in current platform endian, if not DL_ERROR_ENDIAN_ERROR will be returned.
+		A stored packed instance to unpack is required to be in current platform endian, if not DL_ERROR_ENDIAN_ERROR will be returned.
 */
-dl_error_t DL_DLL_EXPORT dl_txt_unpack( dl_ctx_t dl_ctx,                       dl_typeid_t type,
-                                        const unsigned char* packed_instance,  size_t      packed_instance_size,
-                                        char*                out_txt_instance, size_t      out_txt_instance_size,
-                                        size_t*              produced_bytes );
+dl_error_t DL_DLL_EXPORT dl_txt_unpack( dl_ctx_t       dl_ctx,           dl_typeid_t type,
+                                        unsigned char* packed_instance,  size_t      packed_instance_size,
+                                        char*          out_txt_instance, size_t      out_txt_instance_size,
+                                        size_t*        produced_bytes );
+
+/*
+	Function: dl_txt_unpack_loaded
+	    Unpack a loaded binary (without header, with pointers) instance to text-format.
+
+	Parameters:
+	    dl_ctx                - Context to use.
+	    type                  - Type stored in packed_instace.
+	    loaded_instance       - Buffer with loaded data.
+	    out_txt_instance      - Ptr to buffer where to write txt-data.
+	    out_txt_instance_size - Size of out_txt_instance.
+	    produced_bytes        - Number of bytes that would have been written to out_txt_instance if it was large enough.
+
+	Note:
+	    A loaded instance to unpack is required to be in current platform endian, if not DL_ERROR_ENDIAN_ERROR will be returned.
+*/
+dl_error_t DL_DLL_EXPORT dl_txt_unpack_loaded( dl_ctx_t dl_ctx,        dl_typeid_t type,
+                                               const unsigned char* loaded_instance,
+                                               char* out_txt_instance, size_t out_txt_instance_size,
+                                               size_t* produced_bytes );
 
 /*
 	Function: dl_txt_unpack_calc_size
-		Calculate the amount of memory needed to unpack binary data to intermediate data.
+		Calculate the amount of memory needed to unpack packed binary data (with header and offsets) to text-format.
 
 	Parameters:
 		dl_ctx                - Context to use.
@@ -83,8 +103,24 @@ dl_error_t DL_DLL_EXPORT dl_txt_unpack( dl_ctx_t dl_ctx,                       d
 		Packed instance to unpack is required to be in current platform endian, if not DL_ERROR_ENDIAN_ERROR will be returned.
 */
 dl_error_t DL_DLL_EXPORT dl_txt_unpack_calc_size( dl_ctx_t             dl_ctx,               dl_typeid_t type,
-                                                  const unsigned char* packed_instance,      size_t      packed_instance_size,
+                                                  unsigned char* packed_instance,            size_t      packed_instance_size,
                                                   size_t*              out_txt_instance_size );
+
+/*
+	Function: dl_txt_unpack_loaded_calc_size
+	    Calculate the amount of memory needed to unpack loaded binary data (without header, with pointers) to text-format.
+
+	Parameters:
+	    dl_ctx                - Context to use.
+	    type                  - Type stored in packed_instace.
+	    loaded_instance       - Buffer with loaded data.
+	    out_txt_instance_size - Size required to unpack packed_instance.
+
+	Note:
+	    Packed instance to unpack is required to be in current platform endian, if not DL_ERROR_ENDIAN_ERROR will be returned.
+*/
+dl_error_t DL_DLL_EXPORT dl_txt_unpack_loaded_calc_size( dl_ctx_t dl_ctx, dl_typeid_t type,
+                                                         unsigned char* loaded_instance, size_t* out_txt_instance_size );
 
 #ifdef __cplusplus
 }

--- a/src/dl.cpp
+++ b/src/dl.cpp
@@ -527,7 +527,7 @@ dl_error_t dl_instance_store( dl_ctx_t       dl_ctx,     dl_typeid_t type_id,   
 	dl_binary_writer_seek_end( &store_context.writer );
 	if( header )
 	{
-		header->instance_size = (uint32_t)dl_binary_writer_tell( &store_context.writer ) - sizeof( dl_data_header );
+		header->instance_size = uint32_t( dl_binary_writer_tell( &store_context.writer ) - sizeof( dl_data_header ) );
 
 		uintptr_t offset_shift = sizeof( uintptr_t ) * 4;
 		if( dl_binary_writer_tell( &store_context.writer ) >= ( 1ULL << offset_shift ) )

--- a/src/dl_binary_writer.h
+++ b/src/dl_binary_writer.h
@@ -174,7 +174,7 @@ static inline void dl_binary_writer_write_array( dl_binary_writer* writer, const
 }
 
 // val is expected to be in host-endian!!!
-static inline void dl_binary_writer_write_ptr( dl_binary_writer* writer, size_t val )
+static inline void dl_binary_writer_write_ptr( dl_binary_writer* writer, uint64_t val )
 {
 	if( writer->target_endian != DL_ENDIAN_HOST )
 	{

--- a/src/dl_convert.cpp
+++ b/src/dl_convert.cpp
@@ -960,7 +960,7 @@ static dl_error_t dl_internal_convert_instance( dl_ctx_t       dl_ctx,          
 				uint64_t offsets = *(uint64_t*)patch_mem;
 				if( src_endian != DL_ENDIAN_HOST )
 					offsets = dl_swap_endian_uint64( offsets );
-				offset_to_next_pointer_to_patch = offsets >> 32;
+				offset_to_next_pointer_to_patch = uint32_t(offsets >> 32);
 				*(uint64_t*)patch_mem  = *(uint64_t*)patch_mem & patch_mask;
 			}
 		}

--- a/src/dl_convert.cpp
+++ b/src/dl_convert.cpp
@@ -73,10 +73,11 @@ public:
 
 static inline void dl_swap_header( dl_data_header* header )
 {
-	header->id                 = dl_swap_endian_uint32( header->id );
-	header->version            = dl_swap_endian_uint32( header->version );
-	header->root_instance_type = dl_swap_endian_uint32( header->root_instance_type );
-	header->instance_size      = dl_swap_endian_uint32( header->instance_size );
+	header->id                     = dl_swap_endian_uint32( header->id );
+	header->version                = dl_swap_endian_uint32( header->version );
+	header->root_instance_type     = dl_swap_endian_uint32( header->root_instance_type );
+	header->instance_size          = dl_swap_endian_uint32( header->instance_size );
+	header->first_pointer_to_patch = dl_swap_endian_uint32( header->first_pointer_to_patch );
 }
 
 static uintptr_t dl_internal_read_ptr_data( const uint8_t* data,
@@ -793,20 +794,14 @@ static dl_error_t dl_internal_convert_write_instance( dl_ctx_t          dl_ctx,
 #include <algorithm>
 
 bool dl_internal_sort_pred( const SInstance& i1, const SInstance& i2 ) { return i1.address < i2.address; }
+bool dl_internal_search_pred( const SInstance& i1, uintptr_t address ) { return i1.address < (const uint8_t*)address; }
+bool dl_internal_sort_patchpos_pred( const SConvertContext::PatchPos& i1, const SConvertContext::PatchPos& i2 ) { return i1.pos < i2.pos; }
 
-dl_error_t dl_internal_convert_no_header( dl_ctx_t       dl_ctx,
-                                          unsigned char* packed_instance, unsigned char* packed_instance_base,
-                                          unsigned char* out_instance,    size_t         out_instance_size,
-                                          size_t*        needed_size,
-                                          dl_endian_t    src_endian,      dl_endian_t    out_endian,
-                                          dl_ptr_size_t  src_ptr_size,    dl_ptr_size_t  out_ptr_size,
-                                          const dl_type_desc* root_type,  size_t         base_offset )
+dl_error_t dl_internal_convert_no_header( dl_ctx_t            dl_ctx,               unsigned char*   packed_instance,
+                                          unsigned char*      packed_instance_base, SConvertContext& conv_ctx,
+                                          dl_binary_writer*   writer,               size_t*          needed_size,
+                                          const dl_type_desc* root_type )
 {
-	dl_binary_writer writer;
-	dl_binary_writer_init( &writer, out_instance, out_instance_size, out_instance == 0x0, src_endian, out_endian, out_ptr_size );
-
-	SConvertContext conv_ctx( src_endian, out_endian, src_ptr_size, out_ptr_size, dl_ctx->alloc );
-
 	conv_ctx.instances.Add(SInstance(packed_instance, root_type, 0x0, dl_make_type(DL_TYPE_ATOM_POD, DL_TYPE_STORAGE_STRUCT)));
 	dl_error_t err = dl_internal_convert_collect_instances(dl_ctx, root_type, packed_instance, packed_instance_base, conv_ctx);
 
@@ -821,40 +816,55 @@ dl_error_t dl_internal_convert_no_header( dl_ctx_t       dl_ctx,
 		if (dl_type_storage_t((conv_ctx.instances[i].type_id & DL_TYPE_STORAGE_MASK) >> DL_TYPE_STORAGE_MIN_BIT) == DL_TYPE_STORAGE_STR && last_address == conv_ctx.instances[i].address)
 			continue; // Merge identical strings
 		last_address = conv_ctx.instances[i].address;
-		err = dl_internal_convert_write_instance( dl_ctx, conv_ctx.instances[i], &conv_ctx.instances[i].offset_after_patch, conv_ctx, &writer );
+		err = dl_internal_convert_write_instance( dl_ctx, conv_ctx.instances[i], &conv_ctx.instances[i].offset_after_patch, conv_ctx, writer );
 		if(err != DL_ERROR_OK)
 			return err;
 	}
 
-	if(out_instance != 0x0) // no need to patch data if we are only calculating size
+	dl_binary_writer_seek_end( writer );
+	*needed_size = (unsigned int)dl_binary_writer_tell( writer );
+
+	if( !writer->dummy ) // no need to patch data if we are only calculating size
 	{
-		for(unsigned int i = 0; i < conv_ctx.m_lPatchOffset.Len(); ++i)
+		dl_data_header* new_header = (dl_data_header*)writer->data;
+		uintptr_t offset_shift     = ( conv_ctx.target_ptr_size == DL_PTR_SIZE_32BIT ? 4 : 8 ) * 4;
+
+		if( *needed_size >= ( 1ULL << offset_shift ) )
+			new_header->need_slow_patching = 1;
+		else
+			new_header->need_slow_patching = 0;
+		new_header->instance_size = uint32_t( *needed_size - sizeof( dl_data_header ) );
+
+		if( conv_ctx.m_lPatchOffset.Len() )
 		{
-			SConvertContext::PatchPos& pp = conv_ctx.m_lPatchOffset[i];
-
-			// find new offset
-			uintptr_t new_offset = (uintptr_t)-1;
-
-			for( size_t j = 0; j < conv_ctx.instances.Len(); ++j )
+			std::sort( conv_ctx.m_lPatchOffset.m_Ptr, conv_ctx.m_lPatchOffset.m_Ptr + conv_ctx.m_lPatchOffset.Len(), dl_internal_sort_patchpos_pred );
+			conv_ctx.m_lPatchOffset.Add( conv_ctx.m_lPatchOffset[conv_ctx.m_lPatchOffset.Len() - 1] ); // Adding last pointer again so the offset to next pointer becomes 0 which terminates patching
+			for( unsigned int i = 0; i < conv_ctx.m_lPatchOffset.Len() - 1; ++i )
 			{
-				uintptr_t old_offset = (uintptr_t)(conv_ctx.instances[j].address - packed_instance_base);
+				SConvertContext::PatchPos& pp = conv_ctx.m_lPatchOffset[i];
 
-				if(old_offset == pp.old_offset)
+				if( i == 0 && !new_header->need_slow_patching )
+					new_header->first_pointer_to_patch = conv_ctx.tgt_endian != DL_ENDIAN_HOST ? dl_swap_endian_uint32( (uint32_t)pp.pos ) : (uint32_t)pp.pos;
+
+				// find new offset
+				uint64_t new_offset = 0;
+				const SInstance* instance = std::lower_bound( conv_ctx.instances.m_Ptr, conv_ctx.instances.m_Ptr + conv_ctx.instances.Len(), pp.old_offset + (uintptr_t)packed_instance_base, dl_internal_search_pred );
+				if( instance != conv_ctx.instances.m_Ptr + conv_ctx.instances.Len() )
 				{
-					new_offset = conv_ctx.instances[j].offset_after_patch;
-					break;
+					uintptr_t old_offset = (uintptr_t)( instance->address - packed_instance_base );
+					if( old_offset == pp.old_offset )
+						new_offset = instance->offset_after_patch;
 				}
+
+				DL_ASSERT_MSG( new_offset != (uintptr_t)0, "We should have found the instance!" );
+				dl_binary_writer_seek_set( writer, pp.pos );
+				if( !new_header->need_slow_patching )
+					new_offset = new_offset | ( ( (uint64_t)( conv_ctx.m_lPatchOffset[i + 1].pos - conv_ctx.m_lPatchOffset[i].pos ) ) << offset_shift );
+
+				dl_binary_writer_write_ptr( writer, new_offset );
 			}
-
-			DL_ASSERT(new_offset != (uintptr_t)-1 && "We should have found the instance!");
-
-			dl_binary_writer_seek_set( &writer, pp.pos );
-			dl_binary_writer_write_ptr( &writer, new_offset + base_offset );
 		}
 	}
-
-	dl_binary_writer_seek_end( &writer );
-	*needed_size = (unsigned int)dl_binary_writer_tell( &writer );
 
 	return err;
 }
@@ -865,18 +875,20 @@ static dl_error_t dl_internal_convert_instance( dl_ctx_t       dl_ctx,          
                                                 dl_endian_t    out_endian,      size_t      out_ptr_size,
                                                 size_t*        out_size )
 {
-	dl_data_header* header = (dl_data_header*)packed_instance;
+	dl_data_header header = *(dl_data_header*)packed_instance;
 
-	if( packed_instance_size < sizeof(dl_data_header) )             return DL_ERROR_MALFORMED_DATA;
-	if( header->id != DL_INSTANCE_ID &&
-		header->id != DL_INSTANCE_ID_SWAPED )                       return DL_ERROR_MALFORMED_DATA;
-	if( header->version != DL_INSTANCE_VERSION &&
-		header->version != DL_INSTANCE_VERSION_SWAPED )             return DL_ERROR_VERSION_MISMATCH;
-	if( header->root_instance_type != type &&
-		header->root_instance_type != dl_swap_endian_uint32(type) ) return DL_ERROR_TYPE_MISMATCH;
-	if( out_ptr_size != 4 && out_ptr_size != 8 )                    return DL_ERROR_INVALID_PARAMETER;
+	if( packed_instance_size < sizeof(dl_data_header) )            return DL_ERROR_MALFORMED_DATA;
+	if( header.id != DL_INSTANCE_ID &&
+		header.id != DL_INSTANCE_ID_SWAPED )                       return DL_ERROR_MALFORMED_DATA;
+	if( header.version != DL_INSTANCE_VERSION &&
+		header.version != DL_INSTANCE_VERSION_SWAPED &&
+		header.version != 1 &&
+		header.version != dl_swap_endian_uint32(1) )               return DL_ERROR_VERSION_MISMATCH;
+	if( header.root_instance_type != type &&
+		header.root_instance_type != dl_swap_endian_uint32(type) ) return DL_ERROR_TYPE_MISMATCH;
+	if( out_ptr_size != 4 && out_ptr_size != 8 )                   return DL_ERROR_INVALID_PARAMETER;
 
-	dl_ptr_size_t src_ptr_size = header->is_64_bit_ptr != 0 ? DL_PTR_SIZE_64BIT : DL_PTR_SIZE_32BIT;
+	dl_ptr_size_t src_ptr_size = header.is_64_bit_ptr != 0 ? DL_PTR_SIZE_64BIT : DL_PTR_SIZE_32BIT;
 	dl_ptr_size_t dst_ptr_size;
 
 	switch(out_ptr_size)
@@ -890,7 +902,10 @@ static dl_error_t dl_internal_convert_instance( dl_ctx_t       dl_ctx,          
 	if( dst_ptr_size > src_ptr_size && packed_instance == out_instance )
 		return DL_ERROR_UNSUPPORTED_OPERATION;
 
-	dl_endian_t src_endian = header->id == DL_INSTANCE_ID ? DL_ENDIAN_HOST : dl_other_endian( DL_ENDIAN_HOST );
+	dl_endian_t src_endian = header.id == DL_INSTANCE_ID ? DL_ENDIAN_HOST : dl_other_endian( DL_ENDIAN_HOST );
+
+	if (src_endian != DL_ENDIAN_HOST)
+		dl_swap_header(&header);
 
 	if(src_endian == out_endian && src_ptr_size == dst_ptr_size)
 	{
@@ -901,24 +916,17 @@ static dl_error_t dl_internal_convert_instance( dl_ctx_t       dl_ctx,          
 		return DL_ERROR_OK;
 	}
 
-	dl_typeid_t root_type_id = src_endian != DL_ENDIAN_HOST ? dl_swap_endian_uint32( header->root_instance_type ) : header->root_instance_type;
-
-	const dl_type_desc* root_type = dl_internal_find_type(dl_ctx, root_type_id);
+	const dl_type_desc* root_type = dl_internal_find_type(dl_ctx, header.root_instance_type);
 	if(root_type == 0x0)
 		return DL_ERROR_TYPE_NOT_FOUND;
 
-	dl_error_t err = dl_internal_convert_no_header( dl_ctx,
-												    packed_instance + sizeof(dl_data_header),
-												    packed_instance + sizeof(dl_data_header),
-												    out_instance == 0x0 ? 0x0 : out_instance + sizeof(dl_data_header),
-												    out_instance_size - sizeof(dl_data_header),
-												    out_size,
-												    src_endian,
-												    out_endian,
-												    src_ptr_size,
-												    dst_ptr_size,
-												    root_type,
-												    0u );
+	dl_binary_writer writer;
+	dl_binary_writer_init( &writer, out_instance, out_instance_size, out_instance == 0x0, src_endian, out_endian, dst_ptr_size );
+
+	if( packed_instance == out_instance )
+		dl_binary_writer_reserve( &writer, sizeof( dl_data_header ) );
+	else
+		dl_binary_writer_write_zero( &writer, sizeof( dl_data_header ) );
 
 	if(out_instance != 0x0)
 	{
@@ -926,15 +934,61 @@ static dl_error_t dl_internal_convert_instance( dl_ctx_t       dl_ctx,          
 		new_header->id                 = DL_INSTANCE_ID;
 		new_header->version            = DL_INSTANCE_VERSION;
 		new_header->root_instance_type = type;
-		new_header->instance_size      = uint32_t(*out_size);
+		new_header->instance_size      = uint32_t( out_instance_size - sizeof( dl_data_header ) );
 		new_header->is_64_bit_ptr      = out_ptr_size == 4 ? 0 : 1;
 
-		if(DL_ENDIAN_HOST != out_endian)
-			dl_swap_header(new_header);
-	}
+		uintptr_t offset_shift = out_ptr_size * 4;
+		if( out_instance_size >= ( 1ULL << offset_shift ) )
+			new_header->need_slow_patching = 1;
 
-	*out_size += sizeof(dl_data_header);
-	return err;
+		if( DL_ENDIAN_HOST != out_endian )
+			dl_swap_header( new_header );
+	}
+	
+	SConvertContext conv_ctx( src_endian, out_endian, src_ptr_size, dst_ptr_size, dl_ctx->alloc );
+	// While converting we always do slow patching, so neutralize the patch offsets
+	if( header.version == DL_INSTANCE_VERSION && !header.need_slow_patching )
+	{
+		uint32_t offset_to_next_pointer_to_patch = header.first_pointer_to_patch;
+		uint8_t* patch_mem = packed_instance;
+		if( header.is_64_bit_ptr )
+		{
+			uint64_t patch_mask = src_endian == DL_ENDIAN_HOST ? 0xFFFFFFFFULL : 0xFFFFFFFF00000000ULL;
+			while( offset_to_next_pointer_to_patch != 0 ) // 0 is the patch terminator
+			{
+				patch_mem += offset_to_next_pointer_to_patch;
+				uint64_t offsets = *(uint64_t*)patch_mem;
+				if( src_endian != DL_ENDIAN_HOST )
+					offsets = dl_swap_endian_uint64( offsets );
+				offset_to_next_pointer_to_patch = offsets >> 32;
+				*(uint64_t*)patch_mem  = *(uint64_t*)patch_mem & patch_mask;
+			}
+		}
+		else
+		{
+			uint32_t patch_mask = src_endian == DL_ENDIAN_HOST ? 0xFFFFU : 0xFFFF0000U;
+			while( offset_to_next_pointer_to_patch != 0 ) // 0 is the patch terminator
+			{
+				patch_mem += offset_to_next_pointer_to_patch;
+				uint32_t offsets = *(uint32_t*)patch_mem;
+				if( src_endian != DL_ENDIAN_HOST )
+					offsets = dl_swap_endian_uint32( offsets );
+				offset_to_next_pointer_to_patch = offsets >> 16;
+				*(uint32_t*)patch_mem  = *(uint32_t*)patch_mem & patch_mask;
+			}
+		}
+
+		dl_data_header* packed_header = (dl_data_header*)packed_instance;
+		packed_header->need_slow_patching = 1;
+		packed_header->first_pointer_to_patch = 0;
+	}
+	return dl_internal_convert_no_header( dl_ctx,
+										  packed_instance + sizeof(dl_data_header),
+										  packed_instance + (header.version == DL_INSTANCE_VERSION ? 0 : sizeof(dl_data_header)),
+										  conv_ctx,
+										  &writer,
+										  out_size,
+										  root_type );
 }
 
 #ifdef __cplusplus

--- a/src/dl_patch_ptr.cpp
+++ b/src/dl_patch_ptr.cpp
@@ -1,70 +1,48 @@
 #include "dl_patch_ptr.h"
 #include "dl_types.h"
 
-struct dl_patched_ptrs
-{
-	CArrayStatic<const uint8_t*, 128> addresses;
-
-	explicit dl_patched_ptrs(dl_allocator alloc)
-	    : addresses(alloc)
-	{}
-
-	void add( const uint8_t* addr )
-	{
-		DL_ASSERT( !patched( addr ) );
-		addresses.Add(addr);
-	}
-
-	bool patched( const uint8_t* addr )
-	{
-		for (size_t i = 0; i < addresses.Len(); ++i)
-			if( addr == addresses[i] )
-				return true;
-		return false;
-	}
-};
-
 static uintptr_t dl_internal_patch_ptr( uint8_t* ptrptr, uintptr_t patch_distance )
 {
 	union { uint8_t* src; uintptr_t* ptr; };
 	src = ptrptr;
-	if ( *ptr == DL_NULL_PTR_OFFSET[DL_PTR_SIZE_HOST] )
-		*ptr = 0x0;
-	else
+	if( *ptr != 0 )
 		*ptr = *ptr + patch_distance;
 	return *ptr;
 }
 
-void dl_internal_patch_struct( dl_ctx_t            ctx,
-							   const dl_type_desc* type,
-							   uint8_t*            struct_data,
-							   uintptr_t           base_address,
-							   uintptr_t           patch_distance,
-							   dl_patched_ptrs*    patched_ptrs );
+static void dl_internal_patch_struct( dl_ctx_t            ctx,
+									  const dl_type_desc* type,
+									  uint8_t*            struct_data,
+									  uintptr_t           base_address,
+									  uintptr_t           patch_distance,
+									  dl_patched_ptrs*    patched_ptrs,
+									  dl_patched_ptrs*    patched_payloads );
 
 static void dl_internal_patch_ptr_instance( dl_ctx_t            ctx,
 		   	   	   	   	   	   	   	   	    const dl_type_desc* sub_type,
 											uint8_t*            ptr_data,
 											uintptr_t           base_address,
 											uintptr_t           patch_distance,
-											dl_patched_ptrs*    patched_ptrs )
+											dl_patched_ptrs*    patched_ptrs,
+											dl_patched_ptrs*    patched_payloads )
 {
 	uintptr_t offset = dl_internal_patch_ptr( ptr_data, patch_distance );
 	if( offset == 0x0 )
 		return;
 
-	uint8_t* ptr = (uint8_t*)base_address + offset;
-	if( patched_ptrs->patched( ptr ) )
+	uintptr_t ptr = (uintptr_t)base_address + offset;
+	if( patched_payloads->patched( ptr ) )
 		return;
 
-	patched_ptrs->add( ptr );
-	dl_internal_patch_struct( ctx, sub_type, ptr, base_address, patch_distance, patched_ptrs );
+	patched_payloads->add( ptr );
+	dl_internal_patch_struct( ctx, sub_type, (uint8_t*)ptr, base_address, patch_distance, patched_ptrs, patched_payloads );
 }
 
-static void dl_internal_patch_str_array( uint8_t* array_data, uint32_t count, uintptr_t patch_distance )
+static void dl_internal_patch_str_array( uint8_t* array_data, uint32_t count, uintptr_t patch_distance, uintptr_t base_address, dl_patched_ptrs* patched_ptrs )
 {
 	for( uint32_t index = 0; index < count; ++index )
-		dl_internal_patch_ptr( array_data + index * sizeof(char*), patch_distance );
+		if( dl_internal_patch_ptr( array_data + index * sizeof( char* ), patch_distance ) && patched_ptrs )
+			patched_ptrs->add( uintptr_t( array_data + index * sizeof( char* ) - base_address ) );
 }
 
 static void dl_internal_patch_ptr_array( dl_ctx_t            ctx,
@@ -73,10 +51,11 @@ static void dl_internal_patch_ptr_array( dl_ctx_t            ctx,
 										 const dl_type_desc* sub_type,
 										 uintptr_t           base_address,
 										 uintptr_t           patch_distance,
-										 dl_patched_ptrs*    patched_ptrs )
+										 dl_patched_ptrs*    patched_ptrs,
+                                         dl_patched_ptrs*    patched_payloads )
 {
 	for( uint32_t index = 0; index < count; ++index )
-		dl_internal_patch_ptr_instance( ctx, sub_type, array_data + index * sizeof(void*), base_address, patch_distance, patched_ptrs );
+		dl_internal_patch_ptr_instance( ctx, sub_type, array_data + index * sizeof(void*), base_address, patch_distance, patched_ptrs, patched_payloads );
 }
 
 static void dl_internal_patch_struct_array( dl_ctx_t            ctx,
@@ -85,13 +64,14 @@ static void dl_internal_patch_struct_array( dl_ctx_t            ctx,
 											uint32_t            count,
 											uintptr_t           base_address,
 											uintptr_t           patch_distance,
-											dl_patched_ptrs*    patched_ptrs )
+											dl_patched_ptrs*    patched_ptrs,
+											dl_patched_ptrs*    patched_payloads )
 {
 	uint32_t size = dl_internal_align_up( type->size[DL_PTR_SIZE_HOST], type->alignment[DL_PTR_SIZE_HOST] );
 	for( uint32_t index = 0; index < count; ++index )
 	{
 		uint8_t* struct_data = array_data + index * size;
-		dl_internal_patch_struct( ctx, type, struct_data, base_address, patch_distance, patched_ptrs );
+		dl_internal_patch_struct( ctx, type, struct_data, base_address, patch_distance, patched_ptrs, patched_payloads );
 	}
 }
 
@@ -100,7 +80,8 @@ static void dl_internal_patch_member( dl_ctx_t              ctx,
 								      uint8_t*              member_data,
 								      uintptr_t             base_address,
 								      uintptr_t             patch_distance,
-								      dl_patched_ptrs*      patched_ptrs )
+								      dl_patched_ptrs*      patched_ptrs,
+								      dl_patched_ptrs*      patched_payloads )
 {
 	dl_type_atom_t    atom_type    = member->AtomType();
 	dl_type_storage_t storage_type = member->StorageType();
@@ -112,7 +93,8 @@ static void dl_internal_patch_member( dl_ctx_t              ctx,
 			switch( storage_type )
 			{
 				case DL_TYPE_STORAGE_STR:
-					dl_internal_patch_ptr( member_data, patch_distance );
+					if( dl_internal_patch_ptr( member_data, patch_distance ) && patched_ptrs )
+						patched_ptrs->add( uintptr_t(member_data - base_address) );
 				break;
 				case DL_TYPE_STORAGE_PTR:
 					dl_internal_patch_ptr_instance( ctx,
@@ -120,7 +102,8 @@ static void dl_internal_patch_member( dl_ctx_t              ctx,
 													member_data,
 													base_address,
 													patch_distance,
-													patched_ptrs );
+													patched_ptrs,
+													patched_payloads );
 				break;
 				case DL_TYPE_STORAGE_STRUCT:
 					dl_internal_patch_struct( ctx,
@@ -128,7 +111,8 @@ static void dl_internal_patch_member( dl_ctx_t              ctx,
 											  member_data,
 											  base_address,
 											  patch_distance,
-											  patched_ptrs );
+											  patched_ptrs,
+											  patched_payloads );
 				break;
 				default:
 					break;
@@ -141,7 +125,7 @@ static void dl_internal_patch_member( dl_ctx_t              ctx,
 			switch( storage_type )
 			{
 				case DL_TYPE_STORAGE_STR:
-					dl_internal_patch_str_array( member_data, member->inline_array_cnt(), patch_distance );
+					dl_internal_patch_str_array( member_data, member->inline_array_cnt(), patch_distance, base_address, patched_ptrs );
 				break;
 				case DL_TYPE_STORAGE_PTR:
 					dl_internal_patch_ptr_array( ctx,
@@ -150,7 +134,8 @@ static void dl_internal_patch_member( dl_ctx_t              ctx,
 												 dl_internal_find_type( ctx, member->type_id ),
 												 base_address,
 												 patch_distance,
-												 patched_ptrs );
+												 patched_ptrs,
+												 patched_payloads );
 				break;
 				case DL_TYPE_STORAGE_STRUCT:
 					dl_internal_patch_struct_array( ctx,
@@ -159,7 +144,8 @@ static void dl_internal_patch_member( dl_ctx_t              ctx,
 													member->inline_array_cnt(),
 													base_address,
 													patch_distance,
-													patched_ptrs );
+													patched_ptrs,
+													patched_payloads );
 				break;
 				default:
 					break;
@@ -170,9 +156,10 @@ static void dl_internal_patch_member( dl_ctx_t              ctx,
 		case DL_TYPE_ATOM_ARRAY:
 		{
 			uintptr_t offset = dl_internal_patch_ptr( member_data, patch_distance );
+			if( offset && patched_ptrs )
+				patched_ptrs->add( uintptr_t( member_data - base_address ) );
 
-			union { uint8_t* src; uint32_t ptr; };
-			src = member_data + sizeof( void* );
+			uint8_t* src   = member_data + sizeof( void* );
 			uint32_t count = *(uint32_t*)src;
 
 			if( count != 0 )
@@ -181,7 +168,7 @@ static void dl_internal_patch_member( dl_ctx_t              ctx,
 				switch( storage_type )
 				{
 					case DL_TYPE_STORAGE_STR:
-						dl_internal_patch_str_array( array_data, count, patch_distance );
+						dl_internal_patch_str_array( array_data, count, patch_distance, base_address, patched_ptrs );
 					break;
 					case DL_TYPE_STORAGE_PTR:
 						dl_internal_patch_ptr_array( ctx,
@@ -190,7 +177,8 @@ static void dl_internal_patch_member( dl_ctx_t              ctx,
 													 dl_internal_find_type( ctx, member->type_id ),
 													 base_address,
 													 patch_distance,
-													 patched_ptrs );
+													 patched_ptrs,
+													 patched_payloads );
 					break;
 					case DL_TYPE_STORAGE_STRUCT:
 						dl_internal_patch_struct_array( ctx,
@@ -199,7 +187,8 @@ static void dl_internal_patch_member( dl_ctx_t              ctx,
 														count,
 														base_address,
 														patch_distance,
-														patched_ptrs );
+														patched_ptrs,
+														patched_payloads );
 					break;
 					default:
 						break;
@@ -217,7 +206,8 @@ static void dl_internal_patch_union( dl_ctx_t            ctx,
 									 uint8_t*            union_data,
 									 uintptr_t           base_address,
 									 uintptr_t           patch_distance,
-									 dl_patched_ptrs*    patched_ptrs )
+									 dl_patched_ptrs*    patched_ptrs,
+									 dl_patched_ptrs*    patched_payloads )
 {
 	DL_ASSERT(type->flags & DL_TYPE_FLAG_IS_UNION);
 	size_t type_offset = dl_internal_union_type_offset( ctx, type, DL_PTR_SIZE_HOST );
@@ -226,28 +216,29 @@ static void dl_internal_patch_union( dl_ctx_t            ctx,
 	uint32_t union_type = *((uint32_t*)(union_data + type_offset));
 	const dl_member_desc* member = dl_internal_union_type_to_member(ctx, type, union_type);
 	DL_ASSERT(member->offset[DL_PTR_SIZE_HOST] == 0);
-	dl_internal_patch_member( ctx, member, union_data, base_address, patch_distance, patched_ptrs );
+	dl_internal_patch_member( ctx, member, union_data, base_address, patch_distance, patched_ptrs, patched_payloads );
 }
 
-void dl_internal_patch_struct( dl_ctx_t            ctx,
-							   const dl_type_desc* type,
-							   uint8_t*            struct_data,
-							   uintptr_t           base_address,
-							   uintptr_t           patch_distance,
-							   dl_patched_ptrs*    patched_ptrs )
+static void dl_internal_patch_struct( dl_ctx_t            ctx,
+									  const dl_type_desc* type,
+									  uint8_t*            struct_data,
+									  uintptr_t           base_address,
+									  uintptr_t           patch_distance,
+									  dl_patched_ptrs*    patched_ptrs,
+									  dl_patched_ptrs*    patched_payloads )
 {
 	if( type->flags & DL_TYPE_FLAG_HAS_SUBDATA )
 	{
 		if( type->flags & DL_TYPE_FLAG_IS_UNION )
 		{
-			dl_internal_patch_union(ctx, type, struct_data, base_address, patch_distance, patched_ptrs);
+			dl_internal_patch_union( ctx, type, struct_data, base_address, patch_distance, patched_ptrs, patched_payloads );
 		}
 		else
 		{
 			for( uint32_t member_index = 0; member_index < type->member_count; ++member_index )
 			{
 				const dl_member_desc* member = dl_get_type_member( ctx, type, member_index );
-				dl_internal_patch_member( ctx, member, struct_data + member->offset[DL_PTR_SIZE_HOST], base_address, patch_distance, patched_ptrs );
+				dl_internal_patch_member( ctx, member, struct_data + member->offset[DL_PTR_SIZE_HOST], base_address, patch_distance, patched_ptrs, patched_payloads );
 			}
 		}
 	}
@@ -257,10 +248,11 @@ void dl_internal_patch_member( dl_ctx_t              ctx,
 							   const dl_member_desc* member,
 							   uint8_t*              member_data,
 							   uintptr_t             base_address,
-							   uintptr_t             patch_distance )
+							   uintptr_t             patch_distance,
+							   dl_patched_ptrs*      patched_ptrs )
 {
 	dl_patched_ptrs patched(ctx->alloc);
-	dl_internal_patch_member( ctx, member, member_data, base_address, patch_distance, &patched );
+	dl_internal_patch_member( ctx, member, member_data, base_address, patch_distance, patched_ptrs, &patched );
 }
 
 void dl_internal_patch_instance( dl_ctx_t            ctx,
@@ -270,11 +262,11 @@ void dl_internal_patch_instance( dl_ctx_t            ctx,
 								 uintptr_t           patch_distance )
 {
 	dl_patched_ptrs patched(ctx->alloc);
-	patched.add( instance );
+	patched.add( (uintptr_t)instance );
 
 	if( type->flags & DL_TYPE_FLAG_IS_UNION )
 	{
-		dl_internal_patch_union(ctx, type, instance, base_address, patch_distance, &patched);
+		dl_internal_patch_union( ctx, type, instance, base_address, patch_distance, 0, &patched );
 	}
 	else
 	{
@@ -283,7 +275,7 @@ void dl_internal_patch_instance( dl_ctx_t            ctx,
 			const dl_member_desc* member = dl_get_type_member( ctx, type, member_index );
 			uint8_t*   member_data = instance + member->offset[DL_PTR_SIZE_HOST];
 
-			dl_internal_patch_member( ctx, member, member_data, base_address, patch_distance, &patched );
+			dl_internal_patch_member( ctx, member, member_data, base_address, patch_distance, 0, &patched );
 		}
 	}
 }

--- a/src/dl_patch_ptr.h
+++ b/src/dl_patch_ptr.h
@@ -3,6 +3,30 @@
 
 #include "dl_types.h"
 
+struct dl_patched_ptrs
+{
+	CArrayStatic<uintptr_t, 256> addresses;
+
+	explicit dl_patched_ptrs( dl_allocator alloc )
+		: addresses( alloc )
+	{
+	}
+
+	void add( uintptr_t addr )
+	{
+		DL_ASSERT( !patched( addr ) );
+		addresses.Add( addr );
+	}
+
+	bool patched( uintptr_t addr )
+	{
+		for( size_t i = 0; i < addresses.Len(); ++i )
+			if( addr == addresses[i] )
+				return true;
+		return false;
+	}
+};
+
 /**
  * Patch all pointers in an instance.
  *
@@ -26,11 +50,13 @@ void dl_internal_patch_instance( dl_ctx_t            ctx,
  * @param member_data pointer to member to patch.
  * @param base_address base address to patch the pointers against.
  * @param patch_distance distance in bytes to patch all pointers.
+ * @param patched_ptrs keeps a record of all patched ptrs. Can be nullptr
  */
-void dl_internal_patch_member( dl_ctx_t                ctx,
-								 const dl_member_desc* member,
-								 uint8_t*              member_data,
-								 uintptr_t             base_address,
-								 uintptr_t             patch_distance );
+void dl_internal_patch_member( dl_ctx_t              ctx,
+							   const dl_member_desc* member,
+							   uint8_t*              member_data,
+							   uintptr_t             base_address,
+							   uintptr_t             patch_distance,
+							   dl_patched_ptrs*      patched_ptrs );
 
 #endif // DL_PATCH_PTR_H_INCLUDED

--- a/src/dl_txt_pack.cpp
+++ b/src/dl_txt_pack.cpp
@@ -1161,7 +1161,7 @@ static dl_error_t dl_txt_pack_finalize_subdata( dl_ctx_t dl_ctx, dl_txt_pack_ctx
 	packctx->read_ctx.iter = packctx->subdata_pos;
 
 	CArrayStatic<SSubInstance, 256> subinstances(dl_ctx->alloc);
-	subinstances.Add({ { "__root", 6 }, 0, dl_internal_hash_string("__root") });
+	subinstances.Add({ { "__root", 6 }, sizeof(dl_data_header), dl_internal_hash_string("__root") });
 
 	dl_txt_eat_char( dl_ctx, &packctx->read_ctx, '{' );
 

--- a/src/dl_txt_pack.cpp
+++ b/src/dl_txt_pack.cpp
@@ -8,6 +8,7 @@
 
 #include <stdlib.h>
 #include <limits.h>
+#include <algorithm>
 #include <float.h>
 #include <limits>
 
@@ -133,6 +134,7 @@ struct dl_txt_pack_ctx
 {
 	explicit dl_txt_pack_ctx(dl_allocator alloc)
 	    : subdata(alloc)
+	    , ptrs(alloc)
 	{
 	}
 
@@ -146,6 +148,7 @@ struct dl_txt_pack_ctx
 		size_t patch_pos;
 	}; 
 	CArrayStatic<SSubData, 256> subdata;
+	dl_patched_ptrs ptrs;
 };
 
 static void dl_txt_pack_eat_and_write_int8( dl_ctx_t dl_ctx, dl_txt_pack_ctx* packctx )
@@ -223,7 +226,7 @@ static bool dl_txt_pack_eat_and_write_null(dl_txt_pack_ctx* packctx)
 	dl_txt_eat_white( &packctx->read_ctx );
 	if( strncmp( packctx->read_ctx.iter, "null", 4 ) == 0 )
 	{
-		dl_binary_writer_write_ptr( packctx->writer, (uintptr_t)-1 );
+		dl_binary_writer_write_ptr( packctx->writer, (uintptr_t) 0 );
 		packctx->read_ctx.iter += 4;
 		return true;
 	}
@@ -270,6 +273,8 @@ static void dl_txt_pack_eat_and_write_string( dl_ctx_t dl_ctx, dl_txt_pack_ctx* 
 	}
 	dl_binary_writer_write_uint8( packctx->writer, '\0' );
 	dl_binary_writer_seek_set( packctx->writer, curr );
+	if( !packctx->writer->dummy )
+		packctx->ptrs.add( dl_binary_writer_tell( packctx->writer ) );
 	dl_binary_writer_write( packctx->writer, &strpos, sizeof(size_t) );
 }
 
@@ -309,7 +314,10 @@ static void dl_txt_pack_eat_and_write_ptr( dl_ctx_t dl_ctx, dl_txt_pack_ctx* pac
 	if( ptr.str == 0x0 )
 		dl_txt_read_failed( dl_ctx, &packctx->read_ctx, DL_ERROR_TXT_INVALID_MEMBER_TYPE, "expected string" );
 
-	packctx->subdata.Add({ ptr, type, patch_pos });
+	if( !packctx->writer->dummy )
+		packctx->ptrs.add( patch_pos );
+
+	packctx->subdata.Add( { ptr, type, patch_pos } );
 }
 
 static void dl_txt_pack_validate_c_symbol_key( dl_ctx_t dl_ctx, dl_txt_pack_ctx* packctx, dl_substr symbol )
@@ -777,7 +785,7 @@ static void dl_txt_pack_write_default_value( dl_ctx_t              dl_ctx,
 
 		uint8_t* member_data = packctx->writer->data + member_pos;
 		if( !packctx->writer->dummy )
-			dl_internal_patch_member( dl_ctx, member, member_data, (uintptr_t)packctx->writer->data, subdata_pos - member_size );
+			dl_internal_patch_member( dl_ctx, member, member_data, (uintptr_t)packctx->writer->data, subdata_pos - member_size - sizeof( dl_data_header ), &packctx->ptrs );
 	}
 }
 
@@ -832,7 +840,7 @@ static void dl_txt_pack_member( dl_ctx_t dl_ctx, dl_txt_pack_ctx* packctx, size_
 			uint32_t array_length = dl_txt_pack_find_array_length( dl_ctx, packctx, member );
 			if( array_length == 0 )
 			{
-				dl_binary_writer_write_pint( packctx->writer, (size_t)-1 );
+				dl_binary_writer_write_pint( packctx->writer, (size_t)0 );
 				dl_binary_writer_write_uint32( packctx->writer, 0 );
 			}
 			else
@@ -841,6 +849,9 @@ static void dl_txt_pack_member( dl_ctx_t dl_ctx, dl_txt_pack_ctx* packctx, size_
 				dl_txt_pack_array_item_size_align( dl_ctx, member, &element_size, &element_align );
 				size_t array_pos = dl_binary_writer_needed_size( packctx->writer );
 				array_pos = dl_internal_align_up( array_pos, element_align );
+
+	            if( !packctx->writer->dummy )
+				    packctx->ptrs.add( dl_binary_writer_tell( packctx->writer ) );
 
 				dl_binary_writer_write_pint( packctx->writer, array_pos );
 				dl_binary_writer_write_uint32( packctx->writer, array_length );
@@ -1111,6 +1122,13 @@ static void dl_txt_pack_eat_and_write_struct( dl_ctx_t dl_ctx, dl_txt_pack_ctx* 
 	}
 }
 
+struct SSubInstance
+{
+	dl_substr name;
+	size_t pos;
+	uint32_t name_hash;
+};
+
 static dl_error_t dl_txt_pack_finalize_subdata( dl_ctx_t dl_ctx, dl_txt_pack_ctx* packctx )
 {
 	if( packctx->subdata.Len() == 0 )
@@ -1126,7 +1144,7 @@ static dl_error_t dl_txt_pack_finalize_subdata( dl_ctx_t dl_ctx, dl_txt_pack_ctx
 		size_t pos;
 	};
 	CArrayStatic<SSubInstance, 256> subinstances(dl_ctx->alloc);
-	subinstances.Add({ { "__root" , 6}, 0 });
+	subinstances.Add({ { "__root" , 6 }, sizeof(dl_data_header) });
 
 	dl_txt_eat_char( dl_ctx, &packctx->read_ctx, '{' );
 
@@ -1236,12 +1254,12 @@ static const dl_type_desc* dl_txt_pack_inner( dl_ctx_t dl_ctx, dl_txt_pack_ctx* 
 	return 0x0;
 }
 
-dl_error_t dl_txt_pack( dl_ctx_t dl_ctx, const char* txt_instance, unsigned char* out_buffer, size_t out_buffer_size, size_t* produced_bytes )
+dl_error_t dl_txt_pack_internal( dl_ctx_t dl_ctx, const char* txt_instance, unsigned char* out_buffer, size_t out_buffer_size, size_t* produced_bytes, bool use_fast_ptr_patch )
 {
 	dl_binary_writer writer;
 	dl_binary_writer_init( &writer,
-						   out_buffer + sizeof(dl_data_header),
-						   out_buffer_size - sizeof(dl_data_header),
+						   out_buffer,
+						   out_buffer_size,
 						   out_buffer_size == 0,
 						   DL_ENDIAN_HOST,
 						   DL_ENDIAN_HOST,
@@ -1254,30 +1272,55 @@ dl_error_t dl_txt_pack( dl_ctx_t dl_ctx, const char* txt_instance, unsigned char
 	packctx.subdata_pos = 0x0;
 	packctx.read_ctx.err = DL_ERROR_OK;
 
+	dl_binary_writer_write_zero( &writer, sizeof( dl_data_header ) );
 	const dl_type_desc* root_type = dl_txt_pack_inner( dl_ctx, &packctx );
 	if( packctx.read_ctx.err == DL_ERROR_OK )
 	{
 		// write header
 		if( out_buffer_size > 0 )
 		{
-			dl_data_header header;
-			memset(&header, 0x0, sizeof(dl_data_header));
-			header.id                 = DL_INSTANCE_ID;
-			header.version            = DL_INSTANCE_VERSION;
-			header.root_instance_type = dl_internal_typeid_of( dl_ctx, root_type );
-			header.instance_size      = (uint32_t)dl_binary_writer_needed_size( &writer );
-			header.is_64_bit_ptr      = sizeof(void*) == 8 ? 1 : 0;
-			memcpy( out_buffer, &header, sizeof(dl_data_header) );
+			CArrayStatic<uintptr_t, 256>& pointers = packctx.ptrs.addresses;
+
+			dl_data_header& header        = *(dl_data_header*)writer.data;
+			header.id                     = DL_INSTANCE_ID;
+			header.version                = DL_INSTANCE_VERSION;
+			header.root_instance_type     = dl_internal_typeid_of( dl_ctx, root_type );
+			header.instance_size          = (uint32_t)dl_binary_writer_needed_size( &writer ) - sizeof( dl_data_header );
+			header.is_64_bit_ptr          = sizeof( void* ) == 8 ? 1 : 0;
+			header.first_pointer_to_patch = pointers.Len() ? (uint32_t)pointers[0] : 0;
+
+			uintptr_t offset_shift = sizeof( uintptr_t ) * 4;
+			if( dl_binary_writer_needed_size( &writer ) >= ( 1ULL << offset_shift ) || !use_fast_ptr_patch )
+				header.need_slow_patching = 1;
+			else
+			{
+				std::sort( pointers.m_Ptr, pointers.m_Ptr + pointers.m_nElements );
+				if( !packctx.writer->dummy && pointers.Len() )
+				{
+					pointers.Add( pointers[pointers.Len() - 1] ); // Adding last pointer again so the offset to next pointer becomes 0 which terminates patching
+					for( size_t i = 0; i < pointers.Len() - 1; ++i )
+					{
+						uintptr_t offset                                = *(uintptr_t*)&packctx.writer->data[pointers[i]];
+						*(uintptr_t*)&packctx.writer->data[pointers[i]] = offset | ( ( (uintptr_t)( pointers[i + 1] - pointers[i] ) ) << offset_shift );
+					}
+				}
+			}
 		}
 
 		if( produced_bytes )
-			*produced_bytes = (unsigned int)dl_binary_writer_needed_size( &writer ) + sizeof(dl_data_header);
+			*produced_bytes = (unsigned int)dl_binary_writer_needed_size( &writer );
 	}
 	else
 	{
 		dl_report_error_location( dl_ctx, packctx.read_ctx.start, packctx.read_ctx.end, packctx.read_ctx.iter );
 	}
 	return packctx.read_ctx.err;
+}
+
+dl_error_t dl_txt_pack(dl_ctx_t dl_ctx, const char* txt_instance, unsigned char* out_buffer, size_t out_buffer_size, size_t* produced_bytes)
+{
+	bool use_fast_ptr_patch = true;
+	return dl_txt_pack_internal( dl_ctx, txt_instance, out_buffer, out_buffer_size, produced_bytes, use_fast_ptr_patch );
 }
 
 dl_error_t dl_txt_pack_calc_size( dl_ctx_t dl_ctx, const char* txt_instance, size_t* out_instance_size )

--- a/src/dl_txt_pack.cpp
+++ b/src/dl_txt_pack.cpp
@@ -1285,7 +1285,7 @@ dl_error_t dl_txt_pack_internal( dl_ctx_t dl_ctx, const char* txt_instance, unsi
 			header.id                     = DL_INSTANCE_ID;
 			header.version                = DL_INSTANCE_VERSION;
 			header.root_instance_type     = dl_internal_typeid_of( dl_ctx, root_type );
-			header.instance_size          = (uint32_t)dl_binary_writer_needed_size( &writer ) - sizeof( dl_data_header );
+			header.instance_size          = uint32_t(dl_binary_writer_needed_size( &writer ) - sizeof( dl_data_header ));
 			header.is_64_bit_ptr          = sizeof( void* ) == 8 ? 1 : 0;
 			header.first_pointer_to_patch = pointers.Len() ? (uint32_t)pointers[0] : 0;
 

--- a/src/dl_txt_unpack.cpp
+++ b/src/dl_txt_unpack.cpp
@@ -798,10 +798,9 @@ static dl_error_t dl_txt_unpack_root( dl_ctx_t dl_ctx, dl_txt_unpack_ctx* unpack
 	return DL_ERROR_OK;
 }
 
-dl_error_t dl_txt_unpack_loaded( dl_ctx_t dl_ctx,        dl_typeid_t type,
-                                 const unsigned char* loaded_packed_instance,
-                                 char* out_txt_instance, size_t out_txt_instance_size,
-                                 size_t* produced_bytes )
+dl_error_t dl_txt_unpack_loaded( dl_ctx_t    dl_ctx,                 dl_typeid_t type,
+                                 const void* loaded_packed_instance, char*       out_txt_instance,
+	                             size_t      out_txt_instance_size,  size_t*     produced_bytes )
 {
 	dl_binary_writer writer;
 	dl_binary_writer_init( &writer,
@@ -813,7 +812,7 @@ dl_error_t dl_txt_unpack_loaded( dl_ctx_t dl_ctx,        dl_typeid_t type,
 						   DL_PTR_SIZE_HOST );
 
 	dl_txt_unpack_ctx unpackctx( dl_ctx->alloc );
-	unpackctx.packed_instance      = loaded_packed_instance;
+	unpackctx.packed_instance      = reinterpret_cast<const uint8_t*>(loaded_packed_instance);
 	unpackctx.indent               = 0;
 	unpackctx.has_ptrs             = false;
 
@@ -826,7 +825,7 @@ dl_error_t dl_txt_unpack_loaded( dl_ctx_t dl_ctx,        dl_typeid_t type,
 	return err;
 }
 
-dl_error_t dl_txt_unpack_loaded_calc_size( dl_ctx_t dl_ctx, dl_typeid_t type, unsigned char* packed_instance, size_t* out_txt_instance_size )
+dl_error_t dl_txt_unpack_loaded_calc_size( dl_ctx_t dl_ctx, dl_typeid_t type, const void* packed_instance, size_t* out_txt_instance_size )
 {
 	return dl_txt_unpack_loaded( dl_ctx, type, packed_instance, 0x0, 0, out_txt_instance_size );
 }
@@ -838,13 +837,13 @@ dl_error_t dl_txt_unpack( dl_ctx_t       dl_ctx,           dl_typeid_t type,
 {
 	void* loaded_instance;
 	size_t consumed;
-	dl_error_t err = dl_instance_load_inplace( dl_ctx, type, packed_instance, packed_instance_size, &loaded_instance, &consumed );
+	dl_error_t err = dl_instance_load_inplace( dl_ctx, type, (uint8_t*)packed_instance, packed_instance_size, &loaded_instance, &consumed );
 	if( err != DL_ERROR_OK )
 		return err;
-	err = dl_txt_unpack_loaded( dl_ctx, type, (const uint8_t*)loaded_instance, out_txt_instance, out_txt_instance_size, produced_bytes );
+	err = dl_txt_unpack_loaded( dl_ctx, type, (const void*)loaded_instance, out_txt_instance, out_txt_instance_size, produced_bytes );
 	if( err != DL_ERROR_OK )
 		return err;
-	err = dl_instance_store( dl_ctx, type, loaded_instance, packed_instance, packed_instance_size, &consumed );
+	err = dl_instance_store( dl_ctx, type, loaded_instance, (uint8_t*)packed_instance, packed_instance_size, &consumed );
 	return err;
 }
 

--- a/src/dl_txt_unpack.cpp
+++ b/src/dl_txt_unpack.cpp
@@ -17,7 +17,7 @@ struct dl_txt_unpack_ctx
 	int indent;
 	struct SPtr
 	{
-		uintptr_t offset;
+		const uint8_t* ptr;
 		dl_typeid_t tid;
 	};
 	CArrayStatic<SPtr, 256> ptrs;
@@ -54,12 +54,12 @@ static void dl_txt_unpack_write_string( dl_binary_writer* writer, const char* st
 	dl_binary_writer_write_uint8( writer, '\"' );
 }
 
-static void dl_txt_unpack_write_string_or_null( dl_binary_writer* writer, dl_txt_unpack_ctx* unpack_ctx, uintptr_t offset )
+static void dl_txt_unpack_write_string_or_null( dl_binary_writer* writer, const char* str )
 {
-	if( offset == (uintptr_t)-1 )
+	if( str == 0 )
 		dl_binary_writer_write( writer, "null", 4 );
 	else
-		dl_txt_unpack_write_string( writer, (const char*)&unpack_ctx->packed_instance[offset] );
+		dl_txt_unpack_write_string( writer, str );
 }
 
 static void dl_txt_unpack_int8( dl_binary_writer* writer, int8_t data )
@@ -150,20 +150,20 @@ static void dl_txt_unpack_enum( dl_ctx_t dl_ctx, dl_binary_writer* writer, const
 	DL_ASSERT_MSG(false, "failed to find enum value " DL_PINT_FMT_STR, value);
 }
 
-static void dl_txt_unpack_ptr( dl_binary_writer* writer, uintptr_t offset )
+static void dl_txt_unpack_ptr( dl_binary_writer* writer, dl_txt_unpack_ctx* unpack_ctx, const uint8_t* ptr )
 {
-	if( offset == (uintptr_t)-1 )
+	if( ptr == 0 )
 	{
 		dl_binary_writer_write( writer, "null", 4 );
 	}
-	else if( offset == 0 )
+	else if( ptr == unpack_ctx->packed_instance )
 	{
 		dl_binary_writer_write( writer, "\"__root\"", 8 );
 	}
 	else
 	{
 		char buffer[256];
-		dl_internal_str_format( buffer, sizeof(buffer), "ptr_" DL_UINT64_FMT_STR, (uint64_t)offset );
+		dl_internal_str_format( buffer, sizeof( buffer ), "ptr_" DL_UINT64_FMT_STR, (uint64_t)( ptr - unpack_ctx->packed_instance ) );
 		dl_txt_unpack_write_string( writer, buffer );
 	}
 }
@@ -296,10 +296,10 @@ static void dl_txt_unpack_array( dl_ctx_t dl_ctx,
 			uintptr_t* mem = (uintptr_t*)array_data;
 			for( uint32_t i = 0; i < array_count - 1; ++i )
 			{
-				dl_txt_unpack_write_string_or_null( writer, unpack_ctx, mem[i] );
+				dl_txt_unpack_write_string_or_null( writer, (const char*)mem[i] );
 				dl_binary_writer_write( writer, ", ", 2 );
 			}
-			dl_txt_unpack_write_string_or_null( writer, unpack_ctx, mem[array_count - 1] );
+			dl_txt_unpack_write_string_or_null( writer, (const char*)mem[array_count - 1] );
 		}
 		break;
 		case DL_TYPE_STORAGE_PTR:
@@ -307,10 +307,10 @@ static void dl_txt_unpack_array( dl_ctx_t dl_ctx,
 			uintptr_t* mem = (uintptr_t*)array_data;
 			for( uint32_t i = 0; i < array_count - 1; ++i )
 			{
-				dl_txt_unpack_ptr( writer, mem[i] );
+				dl_txt_unpack_ptr( writer, unpack_ctx, (const uint8_t*)mem[i] );
 				dl_binary_writer_write( writer, ", ", 2 );
 			}
-			dl_txt_unpack_ptr( writer, mem[array_count - 1] );
+			dl_txt_unpack_ptr( writer, unpack_ctx, (const uint8_t*)mem[array_count - 1] );
 			unpack_ctx->has_ptrs = true;
 			break;
 		}
@@ -486,10 +486,10 @@ static void dl_txt_unpack_member( dl_ctx_t dl_ctx, dl_txt_unpack_ctx* unpack_ctx
 				case DL_TYPE_STORAGE_ENUM_UINT32: dl_txt_unpack_enum  ( dl_ctx, writer, dl_internal_find_enum( dl_ctx, member->type_id ), (uint64_t)*(uint32_t*) member_data ); break;
 				case DL_TYPE_STORAGE_ENUM_INT64:  dl_txt_unpack_enum  ( dl_ctx, writer, dl_internal_find_enum( dl_ctx, member->type_id ), (uint64_t)*( int64_t*) member_data ); break;
 				case DL_TYPE_STORAGE_ENUM_UINT64: dl_txt_unpack_enum  ( dl_ctx, writer, dl_internal_find_enum( dl_ctx, member->type_id ), (uint64_t)*(uint64_t*) member_data ); break;
-				case DL_TYPE_STORAGE_STR:         dl_txt_unpack_write_string_or_null( writer, unpack_ctx, *(uintptr_t*)member_data ); break;
+				case DL_TYPE_STORAGE_STR:         dl_txt_unpack_write_string_or_null( writer, *(const char**)member_data ); break;
 				case DL_TYPE_STORAGE_PTR:
 				{
-					dl_txt_unpack_ptr( writer, *(uintptr_t*)member_data );
+					dl_txt_unpack_ptr( writer, unpack_ctx, ( const uint8_t* ) * (uintptr_t*)member_data );
 					unpack_ctx->has_ptrs = true;
 				}
 				break;
@@ -501,12 +501,12 @@ static void dl_txt_unpack_member( dl_ctx_t dl_ctx, dl_txt_unpack_ctx* unpack_ctx
 		break;
 		case DL_TYPE_ATOM_ARRAY:
 		{
-			uintptr_t offset = *(uintptr_t*)member_data;
-			uint32_t  count  = *(uint32_t*)(member_data + sizeof(uintptr_t));
-			if( offset == (uintptr_t)-1 )
+			const uint8_t* array = *(const uint8_t**) member_data;
+			uint32_t array_count = *(uint32_t*)( member_data + sizeof( uintptr_t ) );
+			if( array_count == 0 )
 				dl_binary_writer_write( writer, "[]", 2 );
 			else
-				dl_txt_unpack_array( dl_ctx, unpack_ctx, writer, member->StorageType(), &unpack_ctx->packed_instance[offset], count, member->type_id );
+				dl_txt_unpack_array( dl_ctx, unpack_ctx, writer, member->StorageType(), array, array_count, member->type_id );
 		}
 		break;
 		case DL_TYPE_ATOM_INLINE_ARRAY:
@@ -544,30 +544,26 @@ static void dl_txt_unpack_write_subdata_ptr( dl_ctx_t            dl_ctx,
 											 const uint8_t*      ptrptr,
 											 const dl_type_desc* sub_type )
 {
-	uintptr_t offset = *(uintptr_t*)( ptrptr );
-	if( offset == (uintptr_t)-1 )
-		return;
-	if( offset == 0 )
+	const uint8_t* ptr = *(const uint8_t**)( ptrptr );
+	if( ptr == 0 )
 		return;
 
 	for (size_t i = 0; i < unpack_ctx->ptrs.Len(); ++i)
-		if( unpack_ctx->ptrs[i].offset == offset )
+		if( unpack_ctx->ptrs[i].ptr == ptr )
 			return;
 
-	unpack_ctx->ptrs.Add( { offset, 0 } );
+	unpack_ctx->ptrs.Add( { ptr, 0 } );
 
 	dl_txt_unpack_write_indent( writer, unpack_ctx );
-	dl_txt_unpack_ptr( writer, offset );
+	dl_txt_unpack_ptr( writer, unpack_ctx, ptr );
 	dl_binary_writer_write( writer, " : ", 3 );
 
-	DL_ASSERT_MSG(offset < unpack_ctx->packed_instance_size, "Trying to read from offset %d in a buffer of size %d bytes", offset, unpack_ctx->packed_instance_size);
-
-	dl_txt_unpack_struct( dl_ctx, unpack_ctx, writer, sub_type, &unpack_ctx->packed_instance[offset] );
+	dl_txt_unpack_struct( dl_ctx, unpack_ctx, writer, sub_type, ptr );
 
 	// TODO: extra , at last elem =/
 	dl_binary_writer_write( writer, ",\n", 2 );
 
-	dl_txt_unpack_write_subdata( dl_ctx, unpack_ctx, writer, sub_type, &unpack_ctx->packed_instance[offset] );
+	dl_txt_unpack_write_subdata( dl_ctx, unpack_ctx, writer, sub_type, ptr );
 }
 
 static void dl_txt_unpack_write_subdata_ptr_array( dl_ctx_t            dl_ctx,
@@ -655,9 +651,8 @@ static void dl_txt_unpack_write_member_subdata(dl_ctx_t dl_ctx, dl_txt_unpack_ct
 					const dl_type_desc* subtype = dl_internal_find_type( dl_ctx, member->type_id );
 					if( subtype->flags & DL_TYPE_FLAG_HAS_SUBDATA )
 					{
-						uintptr_t array_offset = *(uintptr_t*)(member_data);
-						uint32_t  array_count  = *(uint32_t*)(member_data + sizeof(uintptr_t));
-						const uint8_t* array = unpack_ctx->packed_instance + array_offset;
+						const uint8_t* array = *(const uint8_t**) member_data;
+						uint32_t array_count = *(uint32_t*)(member_data + sizeof(uintptr_t));
 						for( uint32_t i = 0; i < array_count; ++i )
 							dl_txt_unpack_write_subdata( dl_ctx, unpack_ctx, writer, subtype, array + i * subtype->size[DL_PTR_SIZE_HOST] );
 					}
@@ -665,9 +660,8 @@ static void dl_txt_unpack_write_member_subdata(dl_ctx_t dl_ctx, dl_txt_unpack_ct
 				break;
 				case DL_TYPE_STORAGE_PTR:
 				{
-					uintptr_t array_offset = *(uintptr_t*)(member_data);
-					uint32_t  array_count  = *(uint32_t*)(member_data + sizeof(uintptr_t) );
-					const uint8_t* array = unpack_ctx->packed_instance + array_offset;
+					const uint8_t* array = *(const uint8_t**)member_data;
+					uint32_t array_count = *(uint32_t*)(member_data + sizeof(uintptr_t) );
 					dl_txt_unpack_write_subdata_ptr_array( dl_ctx,
 														   unpack_ctx,
 														   writer,
@@ -695,8 +689,6 @@ static void dl_txt_unpack_write_subdata( dl_ctx_t dl_ctx, dl_txt_unpack_ctx* unp
 		// TODO: check if type is not set at all ...
 		size_t type_offset = dl_internal_union_type_offset(dl_ctx, type, DL_PTR_SIZE_HOST);
 
-		DL_ASSERT_MSG(size_t((struct_data + type_offset) - unpack_ctx->packed_instance) < unpack_ctx->packed_instance_size, "Trying to read from offset %d in a buffer of size %d bytes", size_t((struct_data + type_offset) - unpack_ctx->packed_instance), unpack_ctx->packed_instance_size);
-
 		// find member index from union type ...
 		uint32_t union_type = *((uint32_t*)(struct_data + type_offset));
 		const dl_member_desc* member = dl_internal_union_type_to_member(dl_ctx, type, union_type);
@@ -721,8 +713,6 @@ static void dl_txt_unpack_struct( dl_ctx_t dl_ctx, dl_txt_unpack_ctx* unpack_ctx
 	{
 		// TODO: check if type is not set at all ...
 		size_t type_offset = dl_internal_union_type_offset( dl_ctx, type, DL_PTR_SIZE_HOST );
-
-		DL_ASSERT_MSG(size_t((struct_data + type_offset) - unpack_ctx->packed_instance) < unpack_ctx->packed_instance_size, "Trying to read from offset %d in a buffer of size %d bytes", size_t((struct_data + type_offset) - unpack_ctx->packed_instance), unpack_ctx->packed_instance_size);
 
 		// find member index from union type ...
 		uint32_t union_type = *((uint32_t*)(struct_data + type_offset));
@@ -789,19 +779,11 @@ static dl_error_t dl_txt_unpack_root( dl_ctx_t dl_ctx, dl_txt_unpack_ctx* unpack
 	return DL_ERROR_OK;
 }
 
-dl_error_t dl_txt_unpack( dl_ctx_t dl_ctx,                       dl_typeid_t type,
-                          const unsigned char* packed_instance,  size_t      packed_instance_size,
-                          char*                out_txt_instance, size_t      out_txt_instance_size,
-                          size_t*              produced_bytes )
+dl_error_t dl_txt_unpack_loaded( dl_ctx_t dl_ctx,        dl_typeid_t type,
+                                 const unsigned char* loaded_packed_instance,
+                                 char* out_txt_instance, size_t out_txt_instance_size,
+                                 size_t* produced_bytes )
 {
-	dl_data_header* header = (dl_data_header*)packed_instance;
-
-	if( packed_instance_size < sizeof(dl_data_header) ) return DL_ERROR_MALFORMED_DATA;
-	if( header->id == DL_INSTANCE_ID_SWAPED )           return DL_ERROR_ENDIAN_MISMATCH;
-	if( header->id != DL_INSTANCE_ID )                  return DL_ERROR_MALFORMED_DATA;
-	if( header->version != DL_INSTANCE_VERSION)         return DL_ERROR_VERSION_MISMATCH;
-	if( header->root_instance_type != type )            return DL_ERROR_TYPE_MISMATCH;
-
 	dl_binary_writer writer;
 	dl_binary_writer_init( &writer,
 						   (uint8_t*)out_txt_instance,
@@ -811,21 +793,44 @@ dl_error_t dl_txt_unpack( dl_ctx_t dl_ctx,                       dl_typeid_t typ
 						   DL_ENDIAN_HOST,
 						   DL_PTR_SIZE_HOST );
 
-	dl_txt_unpack_ctx unpackctx(dl_ctx->alloc);
-	unpackctx.packed_instance = packed_instance + sizeof(dl_data_header);
-	unpackctx.packed_instance_size = packed_instance_size;
-	unpackctx.indent = 0;
-	unpackctx.has_ptrs = false;
+	dl_txt_unpack_ctx unpackctx( dl_ctx->alloc );
+	unpackctx.packed_instance      = loaded_packed_instance;
+	unpackctx.indent               = 0;
+	unpackctx.has_ptrs             = false;
 
-	dl_txt_unpack_root( dl_ctx, &unpackctx, &writer, header->root_instance_type );
+	unpackctx.ptrs.Add( { unpackctx.packed_instance, type } );
+
+	dl_txt_unpack_root( dl_ctx, &unpackctx, &writer, type );
 	if( produced_bytes )
 		*produced_bytes = writer.needed_size;
 
 	return DL_ERROR_OK;
-};
+}
+
+dl_error_t dl_txt_unpack_loaded_calc_size( dl_ctx_t dl_ctx, dl_typeid_t type, unsigned char* packed_instance, size_t* out_txt_instance_size )
+{
+	return dl_txt_unpack_loaded( dl_ctx, type, packed_instance, 0x0, 0, out_txt_instance_size );
+}
+
+dl_error_t dl_txt_unpack( dl_ctx_t       dl_ctx,           dl_typeid_t type,
+                          unsigned char* packed_instance,  size_t      packed_instance_size,
+                          char*          out_txt_instance, size_t      out_txt_instance_size,
+                          size_t*        produced_bytes )
+{
+	void* loaded_instance;
+	size_t consumed;
+	dl_error_t err = dl_instance_load_inplace( dl_ctx, type, packed_instance, packed_instance_size, &loaded_instance, &consumed );
+	if( err != DL_ERROR_OK )
+		return err;
+	err = dl_txt_unpack_loaded( dl_ctx, type, (const uint8_t*)loaded_instance, out_txt_instance, out_txt_instance_size, produced_bytes );
+	if( err != DL_ERROR_OK )
+		return err;
+	err = dl_instance_store( dl_ctx, type, loaded_instance, packed_instance, packed_instance_size, &consumed );
+	return err;
+}
 
 dl_error_t dl_txt_unpack_calc_size( dl_ctx_t dl_ctx,                           dl_typeid_t type,
-                                    const unsigned char* packed_instance,      size_t      packed_instance_size,
+                                    unsigned char* packed_instance,            size_t      packed_instance_size,
                                     size_t*              out_txt_instance_size )
 {
 	return dl_txt_unpack( dl_ctx, type, packed_instance, packed_instance_size, 0x0, 0, out_txt_instance_size );

--- a/src/dl_typelib_read_txt.cpp
+++ b/src/dl_typelib_read_txt.cpp
@@ -183,6 +183,7 @@ static const dl_builtin_type* dl_find_builtin_type( const char* name )
 }
 
 dl_type_t dl_make_type( dl_type_atom_t atom, dl_type_storage_t storage );
+dl_error_t dl_txt_pack_internal( dl_ctx_t dl_ctx, const char* txt_instance, unsigned char* out_buffer, size_t out_buffer_size, size_t* produced_bytes, bool use_fast_ptr_patch );
 
 static void dl_load_txt_build_default_data( dl_ctx_t ctx, dl_txt_read_ctx* read_state, unsigned int member_index )
 {
@@ -225,7 +226,8 @@ static void dl_load_txt_build_default_data( dl_ctx_t ctx, dl_txt_read_ctx* read_
 
 	uint8_t* pack_buffer = (uint8_t*)dl_alloc( &ctx->alloc, prod_bytes );
 
-	dl_txt_pack( ctx, def_buffer, pack_buffer, prod_bytes, 0x0 );
+	bool use_fast_ptr_patch = false;
+	dl_txt_pack_internal( ctx, def_buffer, pack_buffer, prod_bytes, 0x0, use_fast_ptr_patch );
 
 	// TODO: convert packed instance to typelib endian/ptrsize here!
 

--- a/src/dl_types.h
+++ b/src/dl_types.h
@@ -48,7 +48,7 @@
 #endif
 
 static const uint32_t DL_UNUSED DL_TYPELIB_VERSION         = 4; // format version for type-libraries.
-static const uint32_t DL_UNUSED DL_INSTANCE_VERSION        = 1; // format version for instances.
+static const uint32_t DL_UNUSED DL_INSTANCE_VERSION        = 2; // format version for instances.
 static const uint32_t DL_UNUSED DL_INSTANCE_VERSION_SWAPED = dl_swap_endian_uint32( DL_INSTANCE_VERSION );
 static const uint32_t DL_UNUSED DL_TYPELIB_ID              = ('D'<< 24) | ('L' << 16) | ('T' << 8) | 'L';
 static const uint32_t DL_UNUSED DL_TYPELIB_ID_SWAPED       = dl_swap_endian_uint32( DL_TYPELIB_ID );
@@ -89,8 +89,8 @@ typedef enum
 
 static const uintptr_t DL_NULL_PTR_OFFSET[2] =
 {
-	(uintptr_t)0xFFFFFFFF, // DL_PTR_SIZE_32BIT
-	(uintptr_t)-1          // DL_PTR_SIZE_64BIT
+	(uintptr_t)0, // DL_PTR_SIZE_32BIT
+	(uintptr_t)0  // DL_PTR_SIZE_64BIT
 };
 
 struct dl_typelib_header
@@ -116,7 +116,9 @@ struct dl_data_header
 	dl_typeid_t root_instance_type;
 	uint32_t    instance_size;
 	uint8_t     is_64_bit_ptr; // currently uses uint8 instead of bitfield to be compiler-compliant.
-	uint8_t     pad[7];
+	uint8_t     need_slow_patching; // currently uses uint8 instead of bitfield to be compiler-compliant.
+	uint8_t     pad[2];
+	uint32_t    first_pointer_to_patch;
 };
 
 enum dl_ptr_size_t

--- a/src/dl_util.cpp
+++ b/src/dl_util.cpp
@@ -139,8 +139,8 @@ dl_error_t dl_util_load_from_stream( dl_ctx_t dl_ctx,       	dl_typeid_t        
 			return DL_ERROR_INTERNAL_ERROR;
 	}
 
-	error = dl_instance_load( dl_ctx, type, load_instance, load_size, load_instance, load_size, 0x0 );
-
+	error = dl_instance_load_inplace( dl_ctx, type, load_instance, load_size, out_instance, 0x0 );
+	memmove( load_instance, *out_instance, load_size - sizeof( dl_data_header ) );
 	*out_instance = load_instance;
 
 	if( out_type != 0x0 )

--- a/tests/dl_tests_error.cpp
+++ b/tests/dl_tests_error.cpp
@@ -113,11 +113,11 @@ TEST_F(DLError, version_mismatch_returned)
 	conv.instance = packed;
 	unsigned int* instance_version;
 	instance_version = conv.instance_version + 1;
-	EXPECT_EQ(1u, *instance_version);
+	EXPECT_EQ(2u, *instance_version);
 	*instance_version = 0xFFFFFFFF;
 	conv.instance = swaped;
 	instance_version = conv.instance_version + 1;
-	EXPECT_EQ(0x01000000u, *instance_version);
+	EXPECT_EQ(0x02000000u, *instance_version);
 	*instance_version = 0xFFFFFFFF;
 
 	// test all functions in...

--- a/tests/dl_tests_ptr.cpp
+++ b/tests/dl_tests_ptr.cpp
@@ -215,7 +215,7 @@ TYPED_TEST(DLBase, ptr_chain_long)
 		ptrs[i] = { (uint32_t) i, &ptrs[i + 1] };
 	ptrs[DL_ARRAY_LENGTH(ptrs) - 1] = { DL_ARRAY_LENGTH(ptrs) - 1, &ptrs[0] };
 
-	PtrChain loaded[1024];
+	PtrChain loaded[1030];
 
 	this->do_the_round_about(PtrChain::TYPE_ID, &ptrs, &loaded, sizeof(loaded));
 


### PR DESCRIPTION
For my benchmark test (8,5MB of binary data with a lot of pointers in unions), it used to take 1.92 seconds to patch the pointers on my machine. After this change it takes 0.00056 seconds to do the same thing.

Changing the base address which pointer offsets are calculated from to be the header address instead of the instance root. This means that DL_INSTANCE_VERSION needed to be bumped to 2.
There is backwards compatibility added so old data can be read and re-saved.

Also added more CMake rules, to simplify building and testing on other platforms than Windows.