### PR TITLE
Fix for https://github.com/wc-duck/datalibrary/issues/149

### DIFF
--- a/bam.lua
+++ b/bam.lua
@@ -166,11 +166,7 @@ function make_dl_settings( base_settings )
 	if settings.platform == 'linux_x86' or settings.platform == 'linux_x86_64' then
 		settings.cc.flags:Add("-Wall","-Werror", "-Wextra", "-Wconversion", "-Wstrict-aliasing=2")
 	else
-		--[[
-			/wd4324 = warning C4324: 'SA128BitAlignedType' : structure was padded due to __declspec(align())
-			/wd4127 = warning C4127: conditional expression is constant.
-		--]]
-		settings.cc.flags:Add("/W4", "/WX", "/wd4324", "/wd4127")
+		settings.cc.flags:Add("/W4", "/WX")
 		settings.cc.flags_c:Add("/TP")
 	end
 	return settings

--- a/src/dl_typelib_read_txt.cpp
+++ b/src/dl_typelib_read_txt.cpp
@@ -8,6 +8,14 @@
 #include <stdlib.h> // strtoul
 #include <ctype.h>
 
+#if (__cplusplus >= 201703L) // C++17
+#   define DL_CONSTANT_EXPRESSION(expr) constexpr(expr)
+#elif defined(_MSC_VER)
+#   define DL_CONSTANT_EXPRESSION(expr) (0, (expr))
+#else
+#   define DL_CONSTANT_EXPRESSION(expr) (expr)
+#endif
+
 template <typename T>
 static inline T* dl_grow_array( dl_allocator* alloc, T* ptr, size_t* cap, size_t min_inc )
 {
@@ -404,7 +412,7 @@ static void dl_load_txt_calc_type_size_and_align( dl_ctx_t ctx, dl_txt_read_ctx*
 					{
 						const char* enum_value_name = 0x0;
 						uint32_t enum_value_name_len = 0;
-						if( sizeof(void*) == 8 )
+						if DL_CONSTANT_EXPRESSION( sizeof(void*) == 8 )
 						{
 							enum_value_name = (const char*)( ( (uint64_t)member->size[0] ) | (uint64_t)member->size[1] << 32 );
 							enum_value_name_len = member->alignment[0];
@@ -1045,7 +1053,7 @@ static int dl_parse_type( dl_ctx_t ctx, dl_substr* type, dl_member_desc* member,
 		{
 			// If the inline array size is an enum we have to lookup the size when we are sure that all enums are parsed, temporarily store pointer and string-length
 			// in size/align of member.
-			if( sizeof(void*) == 8 )
+			if DL_CONSTANT_EXPRESSION( sizeof(void*) == 8 )
 			{
 				member->set_size( (uint32_t)( (uint64_t)inline_array_enum_value & 0xFFFFFFFF ), (uint32_t)( ( (uint64_t)inline_array_enum_value >> 32 ) & 0xFFFFFFFF ) );
 				member->set_align( (uint32_t)(inline_array_enum_value_size & 0xFFFFFFFF ), 0 );

--- a/src/dl_typelib_write_c_header.cpp
+++ b/src/dl_typelib_write_c_header.cpp
@@ -823,7 +823,7 @@ static dl_error_t dl_context_write_c_header_types( dl_binary_writer* writer, dl_
 				if (size_without_padding < next_offset )
 				{
 					if (size_without_padding - next_offset >= 8)
-						for (int i = 0; i < (next_offset - size_without_padding) / 8; ++i)
+						for (size_t i = 0; i < (next_offset - size_without_padding) / 8U; ++i)
 							dl_binary_writer_write_string_fmt( writer, "    uint64_t : 64; // Explicit padding to avoid msvc warning 4324\n");
 					else if (size_without_padding - next_offset >= 4)
 						dl_binary_writer_write_string_fmt( writer, "    uint32_t : 32; // Explicit padding to avoid msvc warning 4324\n");


### PR DESCRIPTION
if constexpr where needed and explicit padding generated