### PR TITLE
Fix for C compliant header generation

### DIFF
--- a/src/dl_typelib_write_c_header.cpp
+++ b/src/dl_typelib_write_c_header.cpp
@@ -618,7 +618,7 @@ static dl_error_t dl_context_write_c_header_member( dl_binary_writer* writer, dl
 					dl_enum_info_t sub_type;
 					dl_error_t err = dl_reflect_get_enum_info( ctx, member->type_id, &sub_type );
 					if (DL_ERROR_OK != err) return err;
-					dl_binary_writer_write_string_fmt( writer, "    %s %s;\n", sub_type.name, member->name );
+					dl_binary_writer_write_string_fmt( writer, "    DL_C_ENUM %s %s;\n", sub_type.name, member->name );
 				}
 				break;
 				case DL_TYPE_STORAGE_ENUM_INT64:
@@ -627,7 +627,7 @@ static dl_error_t dl_context_write_c_header_member( dl_binary_writer* writer, dl
 					dl_enum_info_t sub_type;
 					dl_error_t err = dl_reflect_get_enum_info( ctx, member->type_id, &sub_type );
 					if (DL_ERROR_OK != err) return err;
-					dl_binary_writer_write_string_fmt( writer, "    DL_ALIGN(8) %s %s;\n", sub_type.name, member->name );
+					dl_binary_writer_write_string_fmt( writer, "    DL_C_ENUM DL_ALIGN(8) %s %s;\n", sub_type.name, member->name );
 				}
 				break;
 				default:
@@ -655,7 +655,7 @@ static dl_error_t dl_context_write_c_header_member( dl_binary_writer* writer, dl
 		    dl_binary_writer_write_string_fmt(writer, "    DL_DECLARE_ARRAY(");
 		    dl_error_t err = dl_context_write_operator_array_access_type(ctx, member->storage, member->type_id, writer);
 			if (DL_ERROR_OK != err) return err;
-		    dl_binary_writer_write_string_fmt(writer, ") %s;\n ", member->name);
+		    dl_binary_writer_write_string_fmt(writer, ") %s;\n", member->name);
 		}
 		break;
 		case DL_TYPE_ATOM_INLINE_ARRAY:

--- a/src/dl_typelib_write_c_header.cpp
+++ b/src/dl_typelib_write_c_header.cpp
@@ -613,6 +613,13 @@ static dl_error_t dl_context_write_c_header_member( dl_binary_writer* writer, dl
 				case DL_TYPE_STORAGE_ENUM_INT32:
 				case DL_TYPE_STORAGE_ENUM_UINT8:
 				case DL_TYPE_STORAGE_ENUM_UINT16:
+				{
+					dl_enum_info_t sub_type;
+					dl_error_t err = dl_reflect_get_enum_info( ctx, member->type_id, &sub_type );
+					if (DL_ERROR_OK != err) return err;
+					dl_binary_writer_write_string_fmt( writer, "    %s %s;\n", sub_type.name, member->name );
+				}
+				break;
 				case DL_TYPE_STORAGE_ENUM_UINT32:
 				{
 					dl_enum_info_t sub_type;
@@ -627,7 +634,7 @@ static dl_error_t dl_context_write_c_header_member( dl_binary_writer* writer, dl
 					dl_enum_info_t sub_type;
 					dl_error_t err = dl_reflect_get_enum_info( ctx, member->type_id, &sub_type );
 					if (DL_ERROR_OK != err) return err;
-					dl_binary_writer_write_string_fmt( writer, "    DL_C_ENUM DL_ALIGN(8) %s %s;\n", sub_type.name, member->name );
+					dl_binary_writer_write_string_fmt( writer, "    DL_ALIGN(8) %s %s;\n", sub_type.name, member->name );
 				}
 				break;
 				default:

--- a/tests/unittest2.tld
+++ b/tests/unittest2.tld
@@ -94,6 +94,12 @@
 			"members" : [
 				{ "name" : "members", "type" : "complex_member[]" }
 			]
+		},
+		"struct_with_enum" : {
+			// The header generation failed to produce correct C code for this
+			"members" : [
+				{ "name" : "member", "type" : "extern_enum" }
+			]
 		}
 	}
 }


### PR DESCRIPTION
The CMake created Visual Studio project failed to compile `dl_test_valid_c.c` with the included `unittest2.tld` without the fixes made.